### PR TITLE
fix error reporting for `data` field in transaction

### DIFF
--- a/retesteth/RPCSession.cpp
+++ b/retesteth/RPCSession.cpp
@@ -386,7 +386,7 @@ void RPCSession::test_mineBlocks(int _number, string const& _hash)
 {
        (void)_hash;
     u256 startBlock = fromBigEndian<u256>(fromHex(rpcCall("eth_blockNumber").asString()));
-    ETH_FAIL_REQUIRE_MESSAGE(rpcCall("test_mineBlocks", { to_string(_number) }, true) == true, "remote test_mineBlocks = false");
+    ETH_ERROR_REQUIRE_MESSAGE(rpcCall("test_mineBlocks", { to_string(_number) }, true) == true, "remote test_mineBlocks = false");
 
 	// We auto-calibrate the time it takes to mine the transaction.
 	// It would be better to go without polling, but that would probably need a change to the test client

--- a/retesteth/ethObjects/stateTest/scheme_stateTest.cpp
+++ b/retesteth/ethObjects/stateTest/scheme_stateTest.cpp
@@ -76,8 +76,8 @@ scheme_stateTest::fieldChecker::fieldChecker(DataObject const& _test)
             TestOutputHelper::get().testName() + ")");
     for (auto const& element : _test.at("transaction").at("data").getSubObjects())
         ETH_ERROR_REQUIRE_MESSAGE(stringIntegerType(element.asString()) == DigitsType::HexPrefixed,
-            "Field `data` is expected to be binary prefixed with 0x in " +
-                TestOutputHelper::get().testName() + ", but got: " + element.asString());
+            "Field `data` in `transaction` section is expected to be binary prefixed with `0x` in " +
+                TestOutputHelper::get().testName() + ", but got: `" + element.asString() + "`");
 }
 
 scheme_stateTestFiller::fieldChecker::fieldChecker(DataObject const& _test)


### PR DESCRIPTION
do not fail on test_mineblock timeout