### PR TITLE
docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,37 @@
-FROM ubuntu
-RUN apt-get update
-RUN apt-get install \
-        git \
-        cmake \
-        g++ \
-        make \
-        perl -y
+FROM ubuntu:18.04 as retesteth-build
+RUN apt-get update \
+    && apt-get install --yes git cmake g++ make perl psmisc  \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --recursive https://github.com/ethereum/retesteth --branch master --single-branch --depth 1
-RUN mkdir /build
-RUN cd /build && cmake /retesteth -DCMAKE_BUILD_TYPE=Release
-RUN cd /build && make -j8
-RUN cp /build/retesteth/retesteth /usr/bin/retesteth
-RUN cd / && rm /build -rf \
-    && rm /retesteth -rf \
-    && rm /var/cache/* -rf \
-    && rm /root/.hunter/* -rf
+# Retesteth
+# ADD . /retesteth
+RUN git clone --depth 1 -b develop https://github.com/ethereum/retesteth.git /retesteth
+RUN mkdir /build && cd /build \
+    && cmake /retesteth -DCMAKE_BUILD_TYPE=Release \
+    && make -j8 \
+    && cp /build/retesteth/retesteth /usr/bin/retesteth \
+    && rm -rf /build /retesteth /var/cache/* /root/.hunter/*
+
+#RUN git clone --depth 1 -b master https://github.com/ethereum/tests /tests
+
+# Solidity
+RUN git clone --depth 1 -b master https://github.com/winsvega/solidity.git /solidity
+RUN mkdir /build && cd /build \
+    && apt-get update \
+    && apt-get install --yes libboost-all-dev \
+    && cmake /solidity -DCMAKE_BUILD_TYPE=Release -DLLL=1 && make lllc \
+    && cp /build/lllc/lllc /bin/lllc \
+    && rm -rf /build /solidity /var/cache/* /root/.hunter/*
+
+
+# Geth
+RUN git clone --depth 1 -b master https://github.com/ethereum/go-ethereum.git /geth
+RUN cd /geth && apt-get install wget \
+    && wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz \
+    && tar -xvf go1.13.3.linux-amd64.tar.gz \
+    && mv go /usr/local && ln -s /usr/local/go/bin/go /bin/go \
+    && make all && cp /geth/build/bin/evm /bin/evm \
+    && cp /geth/build/bin/geth /bin/geth \
+    && rm -rf /geth && rm -rf /usr/local/go
 
 ENTRYPOINT ["/usr/bin/retesteth"]

--- a/dretesteth.sh
+++ b/dretesteth.sh
@@ -1,0 +1,36 @@
+buildImage () {
+    docker build -t retesteth .
+    exit 0
+}
+
+case $1 in
+    "build")
+        buildImage
+        ;;
+esac
+
+# Parse arguments and intercept --testpath argument for docker
+separator=0
+testpaths=0
+testpath="notfound"
+argstring=""
+for var in "$@"
+do
+    if [ "$var" = "--" ]; then
+        separator=1
+        argstring=$argstring" "$var
+        continue
+    fi
+    if [ "$var" = "--testpath" ] && [ "$separator" -eq "1" ]; then
+        testpaths=1
+        continue
+    fi
+    if [ "$testpaths" -eq "1" ]; then
+        testpaths=0
+        testpath=$var
+        continue
+    fi
+    argstring=$argstring" "$var
+done
+
+docker run -v $testpath:/tests retesteth $argstring --testpath /tests --clients "t8ntool"

--- a/dretesteth.sh
+++ b/dretesteth.sh
@@ -9,11 +9,13 @@ case $1 in
         ;;
 esac
 
+
 # Parse arguments and intercept --testpath argument for docker
 separator=0
 testpaths=0
 testpath="notfound"
 argstring=""
+clientsopt=0
 for var in "$@"
 do
     if [ "$var" = "--" ]; then
@@ -30,7 +32,15 @@ do
         testpath=$var
         continue
     fi
+    if [ "$var" = "--clients" ] && [ "$separator" -eq "1" ]; then
+        clientsopt=1
+    fi
     argstring=$argstring" "$var
 done
 
-docker run -v $testpath:/tests retesteth $argstring --testpath /tests --clients "t8ntool"
+defaultclient="--clients t8ntool"
+if [ "$clientsopt" -eq "1" ]; then
+   defaultclient=""
+fi
+
+docker run -v $testpath:/tests retesteth $argstring --testpath /tests $defaultclient

--- a/retesteth/ExitHandler.cpp
+++ b/retesteth/ExitHandler.cpp
@@ -21,6 +21,8 @@ void ExitHandler::doExit()
     if (!runOnce)
     {
         // must be run after all TestOutputHelper::finishTest methods are called;
+        // keep an eye on std::lock_guard<std::mutex> lock(g_numberOfRunningTests);
+        // numberOfRunningTests--; variable might be wrong.
         while (!TestOutputHelper::isAllTestsFinished())
         {
             static int totaltime = 0;

--- a/retesteth/Options.cpp
+++ b/retesteth/Options.cpp
@@ -73,7 +73,7 @@ void printHelp()
     cout << setw(30) << "--travisout" << setw(25) << "Output `.` to stdout\n";
 
     cout << "\nAdditional Tests\n";
-    cout << setw(30) << "--all" << setw(25) << "Enable all tests\n";
+    cout << setw(30) << "--all" << setw(0) << "Enable all tests\n";
     cout << setw(30) << "--lowcpu" << setw(25) << "Disable cpu intense tests\n";
 
     cout << "\nTest Generation\n";

--- a/retesteth/TestOutputHelper.cpp
+++ b/retesteth/TestOutputHelper.cpp
@@ -148,14 +148,12 @@ void TestOutputHelper::initTest(size_t _maxTests)
     m_currentTestName = string();
     m_currentTestFileName = string();
     m_timer = Timer();
-    m_isRunning = false;
     if (!Options::get().createRandomTest && _maxTests != 0 && !Options::get().singleTestFile)
     {
         std::cout << "Test Case \"" + TestInfo::caseName() + "\": \n";
         std::lock_guard<std::mutex> lock(g_numberOfRunningTests);
         numberOfRunningTests++;
         m_timer.restart();
-        m_isRunning = true;
     }
     m_maxTests = _maxTests;
     m_currTest = 0;
@@ -189,9 +187,6 @@ void TestOutputHelper::showProgress()
 std::mutex g_execTimeResults;
 void TestOutputHelper::finishTest()
 {
-    if (!m_isRunning)
-        return;
-    m_isRunning = false;
     if (Options::get().exectimelog)
     {
         std::cout << "Tests finished: " << m_currTest << std::endl;

--- a/retesteth/TestOutputHelper.h
+++ b/retesteth/TestOutputHelper.h
@@ -129,7 +129,6 @@ private:
     size_t m_maxTests;
     std::string m_currentTestName;
     TestInfo m_testInfo;
-    bool m_isRunning;
     boost::filesystem::path m_currentTestFileName;
     std::vector<std::string> m_errors; //flag errors for triggering boost erros after all thread finished
     std::vector<std::string> m_expected_UnitTestExceptions;  // expect following errors


### PR DESCRIPTION
there is a script in retesteth repo. just run
`dretesteth.sh build`
then use `dretesteth.sh` as retesteth command. 
 `--testpath folder` will be mounted into docker. tests are executed/generated with geth transition tool.

tested with `Docker version 19.03.8, build afacb8b7f0`

there is option `--datadir` that will export retesteth datadirectory. 
```
dretesteth.sh -- --testpath /home/user/tests --datadir /tests/.retesteth
(/home/user/tests is mounted into docker /tests)
```

will export retesteth configs into mounted tests path into `.retesteth` folder so it would be possible to connect your own client
using 

```
dretesteth.sh -t GeneralStateTests/stExample -- --clients "configname"
```

that would require to configure your client for retesteth at `/home/user/tests/.retesteth` 
pay a note to `start.sh` and `stop.sh`
if your client executable is located at docker mounted folder (`/home/user/tests/.retesteth`) docker should be able to run it (from `/tests/.retesteth`).

```
