### PR TITLE
Apr 28   fix out of memory

### DIFF
--- a/retesteth/configs/clientconfigs/oewrap.cpp
+++ b/retesteth/configs/clientconfigs/oewrap.cpp
@@ -171,7 +171,7 @@ var logMsgNum = 1
 
 // Debug function
 const logMe = str => {
-  if (true)   // true to turn on logging, false to turn it off
+  if (false)   // true to turn on logging, false to turn it off
     fs.appendFileSync(logFile, `###### LOG MESSAGE ${logMsgNum++} ######\n${str}\n`)
 }
 


### PR DESCRIPTION
1. Changed `logHash` to a clearly fake value. Now that `retesteth` doesn't test it by default, that's better than a value that looks real.
2. Fixed a memory issue that affected tests with huge traces
3. Removed the trace option, which will require work to get it to work with the solution to the memory issue above