### PR TITLE
Optimize DataObject [PoC RC]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ HunterGate(
 )
 
 project(retesteth VERSION 0.1.2)
-set(VERSION_SUFFIX "london")
+set(VERSION_SUFFIX "london-spdataobj")
 
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)

--- a/retesteth/TestHelper.cpp
+++ b/retesteth/TestHelper.cpp
@@ -556,10 +556,11 @@ fs::path createUniqueTmpDirectory() {
     std::lock_guard<std::mutex> lock(g_createUniqueTmpDirectory);
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
     string uuidStr = boost::lexical_cast<string>(uuid);
-    if (fs::exists(fs::temp_directory_path() / uuidStr))
+    auto tpath = fs::temp_directory_path();
+    if (fs::exists(tpath / uuidStr))
         ETH_FAIL_MESSAGE("boost create tmp directory which already exist!");
-    boost::filesystem::create_directory(fs::temp_directory_path() / uuidStr);
-    return fs::temp_directory_path() / uuidStr;
+    boost::filesystem::create_directory(tpath / uuidStr);
+    return tpath / uuidStr;
 }
 
 }//namespace

--- a/retesteth/TestHelper.cpp
+++ b/retesteth/TestHelper.cpp
@@ -39,7 +39,7 @@ Json::Value readJson(fs::path const& _file)
 #endif
 
 /// Safely read the json file into DataObject
-DataObject readJsonData(fs::path const& _file, string const& _stopper, bool _autosort)
+spDataObject readJsonData(fs::path const& _file, string const& _stopper, bool _autosort)
 {
     try
     {
@@ -51,7 +51,7 @@ DataObject readJsonData(fs::path const& _file, string const& _stopper, bool _aut
     catch (std::exception const& _ex)
     {
         ETH_ERROR_MESSAGE(string("\nError when parsing file (") + _file.c_str() + ") " + _ex.what());
-        return DataObject();
+        return spDataObject(0);
     }
 }
 

--- a/retesteth/TestHelper.cpp
+++ b/retesteth/TestHelper.cpp
@@ -222,8 +222,8 @@ void parseJsonStrValueIntoSet(DataObject const& _json, set<string>& _out)
     {
         for (auto const& val: _json.getSubObjects())
         {
-            ETH_ERROR_REQUIRE_MESSAGE(val.type() == DataType::String, "parseJsonStrValueIntoSet expected value type = string!");
-            _out.emplace(val.asString());
+            ETH_ERROR_REQUIRE_MESSAGE(val->type() == DataType::String, "parseJsonStrValueIntoSet expected value type = string!");
+            _out.emplace(val->asString());
         }
     }
     else
@@ -261,12 +261,12 @@ void parseJsonIntValueIntoSet(DataObject const& _json, set<int>& _out)
     {
         for (auto const& val: _json.getSubObjects())
         {
-            if (val.type() == DataType::Integer)
-                _out.emplace(val.asInt());
+            if (val->type() == DataType::Integer)
+                _out.emplace(val->asInt());
             else
             {
                 ETH_ERROR_REQUIRE_MESSAGE(
-                    val.type() == DataType::String, "parseJsonIntValueIntoSet expected value type = int, \"int-int\" range!");
+                    val->type() == DataType::String, "parseJsonIntValueIntoSet expected value type = int, \"int-int\" range!");
                 parseRange(val);
             }
         }

--- a/retesteth/TestHelper.cpp
+++ b/retesteth/TestHelper.cpp
@@ -556,7 +556,7 @@ fs::path createUniqueTmpDirectory() {
     std::lock_guard<std::mutex> lock(g_createUniqueTmpDirectory);
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
     string uuidStr = boost::lexical_cast<string>(uuid);
-    auto tpath = fs::temp_directory_path();
+    static auto tpath = fs::exists("/dev/shm") ? fs::path("/dev/shm") : fs::temp_directory_path();
     if (fs::exists(tpath / uuidStr))
         ETH_FAIL_MESSAGE("boost create tmp directory which already exist!");
     boost::filesystem::create_directory(tpath / uuidStr);

--- a/retesteth/TestHelper.cpp
+++ b/retesteth/TestHelper.cpp
@@ -56,7 +56,7 @@ spDataObject readJsonData(fs::path const& _file, string const& _stopper, bool _a
 }
 
 /// Safely read the yaml file into DataObject
-DataObject readYamlData(fs::path const& _file)
+spDataObject readYamlData(fs::path const& _file)
 {
     try
     {
@@ -68,7 +68,7 @@ DataObject readYamlData(fs::path const& _file)
     catch (std::exception const& _ex)
     {
         ETH_ERROR_MESSAGE(string("\nError when parsing file (") + _file.c_str() + ") " + _ex.what());
-        return DataObject();
+        return spDataObject(0);
     }
 }
 

--- a/retesteth/TestHelper.h
+++ b/retesteth/TestHelper.h
@@ -23,9 +23,9 @@ Json::Value readJson(fs::path const& _path);
 #endif
 
 /// Safely read the json file into DataObject
-DataObject readJsonData(
+spDataObject readJsonData(
     fs::path const& _file, string const& _stopper = string(), bool _autosort = false);
-DataObject readYamlData(fs::path const& _file);
+spDataObject readYamlData(fs::path const& _file);
 
 /// Get files from directory
 std::vector<boost::filesystem::path> getFiles(boost::filesystem::path const& _dirPath, std::set<std::string> _extentionMask, std::string const& _particularFile = {});

--- a/retesteth/TestSuite.cpp
+++ b/retesteth/TestSuite.cpp
@@ -89,12 +89,12 @@ void removeComments(DataObject& _obj)
 		list<string> removeList;
         for (auto& i: _obj.getSubObjectsUnsafe())
 		{
-            if (i.getKey().substr(0, 2) == "//")
+            if (i->getKey().substr(0, 2) == "//")
 			{
-                removeList.push_back(i.getKey());
+                removeList.push_back(i->getKey());
 				continue;
 			}
-            removeComments(i);
+            removeComments(i.getContent());
 		}
         for (auto const& i: removeList)
             _obj.removeKey(i);
@@ -102,15 +102,16 @@ void removeComments(DataObject& _obj)
     else if (_obj.type() == DataType::Array)
     {
         for (auto& i: _obj.getSubObjectsUnsafe())
-			removeComments(i);
+            removeComments(i.getContent());
     }
 }
 
 void addClientInfo(DataObject& _v, fs::path const& _testSource, h256 const& _testSourceHash)
 {
     SessionInterface& session = RPCSession::instance(TestOutputHelper::getThreadID());
-    for (auto& o : _v.getSubObjectsUnsafe())
+    for (auto& o2 : _v.getSubObjectsUnsafe())
     {
+        DataObject& o = o2.getContent();
         string comment;
         DataObject clientinfo;
         clientinfo.setKey("_info");
@@ -141,8 +142,9 @@ void checkFillerHash(fs::path const& _compiledTest, fs::path const& _sourceTest)
 {
     DataObject v = test::readJsonData(_compiledTest, "_info");
     TestFileData fillerData = readTestFile(_sourceTest);
-    for (auto const& i: v.getSubObjects())
+    for (auto const& i2: v.getSubObjects())
     {
+        DataObject const& i = i2.getCContent();
         try
         {
             // use eth object _info section class here !!!!!

--- a/retesteth/TestSuite.cpp
+++ b/retesteth/TestSuite.cpp
@@ -121,11 +121,11 @@ void addClientInfo(DataObject& _v, fs::path const& _testSource, h256 const& _tes
             if (existingInfo.count("comment"))
                 comment = existingInfo.atKey("comment").asString();
             if (existingInfo.count("labels"))
-                (*clientinfo)["labels"] = existingInfo.atKey("labels");
+                (*clientinfo)["labels"].copyFrom(existingInfo.atKey("labels"));
         }
 
         (*clientinfo)["comment"] = comment;
-        (*clientinfo)["filling-rpc-server"] = session.web3_clientVersion();
+        (*clientinfo)["filling-rpc-server"] = session.web3_clientVersion()->asString();
         (*clientinfo)["filling-tool-version"] = test::prepareVersionString();
         (*clientinfo)["lllcversion"] = test::prepareLLLCVersionString();
         (*clientinfo)["source"] = _testSource.string();
@@ -255,9 +255,9 @@ void TestSuite::runTestWithoutFiller(boost::filesystem::path const& _file) const
                     TestSuiteOptions opt;
                     opt.doFilling = true;
                     opt.allowInvalidBlocks = true;
-                    DataObject output = doTests(testData.data, opt);
-                    addClientInfo(output, _file, testData.hash);
-                    writeFile(outPath, asBytes(output.asJson()));
+                    spDataObject output = doTests(testData.data, opt);
+                    addClientInfo(output.getContent(), _file, testData.hash);
+                    writeFile(outPath, asBytes(output->asJson()));
                 }
                 else
                     executeFile(_file);
@@ -589,8 +589,8 @@ void TestSuite::executeTest(string const& _testFolder, fs::path const& _testFile
                 ETH_LOG("Copying " + _testFileName.string(), 0);
                 ETH_LOG(" TO " + boostTestPath.path().string(), 0);
                 assert(_testFileName.string() != boostTestPath.path().string());
-                addClientInfo(testData.data, boostRelativeTestPath, testData.hash);
-                writeFile(boostTestPath.path(), asBytes(testData.data.asJson()));
+                addClientInfo(testData.data.getContent(), boostRelativeTestPath, testData.hash);
+                writeFile(boostTestPath.path(), asBytes(testData.data->asJson()));
                 ETH_FAIL_REQUIRE_MESSAGE(boost::filesystem::exists(boostTestPath.path().string()),
                     "Error when copying the test file!");
             }
@@ -601,10 +601,10 @@ void TestSuite::executeTest(string const& _testFolder, fs::path const& _testFile
 
                 try
                 {
-                    DataObject output = doTests(testData.data, opt);
+                    spDataObject output = doTests(testData.data, opt);
                     // Add client info for all of the tests in output
-                    addClientInfo(output, boostRelativeTestPath, testData.hash);
-                    writeFile(boostTestPath.path(), asBytes(output.asJson()));
+                    addClientInfo(output.getContent(), boostRelativeTestPath, testData.hash);
+                    writeFile(boostTestPath.path(), asBytes(output->asJson()));
 
                     if (!Options::get().getGStateTransactionFilter().empty())
                     {

--- a/retesteth/TestSuite.h
+++ b/retesteth/TestSuite.h
@@ -85,7 +85,7 @@ public:
     };
 
     // Main test executive function. should be declared for each test suite. it fills and runs the test .json file
-    virtual DataObject doTests(DataObject const&, TestSuiteOptions& _options) const = 0;
+    virtual spDataObject doTests(DataObject const&, TestSuiteOptions& _options) const = 0;
 
 	// Execute all tests from suiteFolder()/_testFolder/*
 	// This functions checks that tests in the repo are updated with /src/suiteFillerFolder()/*Filler tests

--- a/retesteth/compiler/Compiler.cpp
+++ b/retesteth/compiler/Compiler.cpp
@@ -79,7 +79,7 @@ string replaceCode(string const& _code, solContracts const& _preSolidity)
         solContracts const contracts = compileSolidity(_code);
         if (contracts.Contracts().size() > 1)
             ETH_ERROR_MESSAGE("Compiling solc: Only one solidity contract is allowed per address!");
-        compiledCode = contracts.Contracts().at(0).asString();
+        compiledCode = contracts.Contracts().at(0)->asString();
     }
     else if (_code.find(c_solidityPrefix) != string::npos)
     {

--- a/retesteth/compiler/Compiler.h
+++ b/retesteth/compiler/Compiler.h
@@ -23,7 +23,7 @@ class solContracts
 public:
     void insertCode(string const& _name, string const& _code) { m_solContracts[_name] = _code; }
     string const& getCode(string const& _contractName) const;
-    std::vector<DataObject> const& Contracts() const { return m_solContracts.getSubObjects(); }
+    std::vector<spDataObject> const& Contracts() const { return m_solContracts.getSubObjects(); }
 
 private:
     // Map of "contractName" -> "bytecode"

--- a/retesteth/compiler/Compiler.h
+++ b/retesteth/compiler/Compiler.h
@@ -21,13 +21,14 @@ string encodeAbi(string const& _code);
 class solContracts
 {
 public:
-    void insertCode(string const& _name, string const& _code) { m_solContracts[_name] = _code; }
+    solContracts() { m_solContracts = spDataObject(new DataObject()); }
+    void insertCode(string const& _name, string const& _code) { m_solContracts.getContent()[_name] = _code; }
     string const& getCode(string const& _contractName) const;
-    std::vector<spDataObject> const& Contracts() const { return m_solContracts.getSubObjects(); }
+    std::vector<spDataObject> const& Contracts() const { return m_solContracts->getSubObjects(); }
 
 private:
     // Map of "contractName" -> "bytecode"
-    DataObject m_solContracts;
+    spDataObject m_solContracts;
 };
 
 /// get solContracts information from solidity source code

--- a/retesteth/compiler/Solidity.cpp
+++ b/retesteth/compiler/Solidity.cpp
@@ -292,10 +292,10 @@ string EncodeArgument(string const& _element, ArgumentSignature const& _sig)
 
 string const& test::compiler::solContracts::getCode(string const& _contractName) const
 {
-    if (!m_solContracts.count(_contractName))
+    if (!m_solContracts->count(_contractName))
         ETH_ERROR_MESSAGE("solContracts::getCode: error contract name: `" + _contractName +
                           "` not found! (Specify contract in \"solidity\": section of the test filler)");
-    return m_solContracts.atKey(_contractName).asString();
+    return m_solContracts->atKey(_contractName).asString();
 }
 
 // Encode Solidity abi

--- a/retesteth/configs/ClientConfig.cpp
+++ b/retesteth/configs/ClientConfig.cpp
@@ -61,17 +61,17 @@ ClientConfig::ClientConfig(fs::path const& _clientConfigPath) : m_id(ClientConfi
         fs::path correctMiningRewardPath = genesisTemplatePath / "correctMiningReward.json";
         ETH_FAIL_REQUIRE_MESSAGE(fs::exists(correctMiningRewardPath),
             "correctMiningReward.json client config not found!");
-        DataObject correctMiningReward = test::readJsonData(correctMiningRewardPath);
-        correctMiningReward.performModifier(mod_removeComments);
-        correctMiningReward.performModifier(mod_valueToCompactEvenHexPrefixed);
+        spDataObject correctMiningReward = test::readJsonData(correctMiningRewardPath);
+        correctMiningReward.getContent().performModifier(mod_removeComments);
+        correctMiningReward.getContent().performModifier(mod_valueToCompactEvenHexPrefixed);
         for (auto const& el : cfgFile().forks())
         {
-            if (!correctMiningReward.count(el.asString()))
+            if (!correctMiningReward->count(el.asString()))
                 ETH_FAIL_MESSAGE("Correct mining reward missing block reward record for fork: `" +
                                  el.asString() + "` (" + correctMiningRewardPath.string() + ")");
         }
-        for (auto const& el : correctMiningReward.getSubObjects())
-            m_correctReward[el->getKey()] = spVALUE(new VALUE(correctMiningReward.atKey(el->getKey())));
+        for (auto const& el : correctMiningReward->getSubObjects())
+            m_correctReward[el->getKey()] = spVALUE(new VALUE(correctMiningReward->atKey(el->getKey())));
     }
     catch (std::exception const& _ex)
     {
@@ -207,9 +207,9 @@ std::string const& ClientConfig::translateException(string const& _exceptionName
 }
 
 // Get Contents of genesis template for specified FORK
-DataObject const& ClientConfig::getGenesisTemplate(FORK const& _fork) const
+spDataObject const& ClientConfig::getGenesisTemplate(FORK const& _fork) const
 {
-    ETH_FAIL_REQUIRE_MESSAGE(m_genesisTemplate.count(FORK(_fork)),
+    ETH_FAIL_REQUIRE_MESSAGE(m_genesisTemplate.count(_fork),
         "Genesis template for network '" + _fork.asString() + "' not found!");
     return m_genesisTemplate.at(_fork);
 }

--- a/retesteth/configs/ClientConfig.cpp
+++ b/retesteth/configs/ClientConfig.cpp
@@ -71,7 +71,7 @@ ClientConfig::ClientConfig(fs::path const& _clientConfigPath) : m_id(ClientConfi
                                  el.asString() + "` (" + correctMiningRewardPath.string() + ")");
         }
         for (auto const& el : correctMiningReward.getSubObjects())
-            m_correctReward[el.getKey()] = spVALUE(new VALUE(correctMiningReward.atKey(el.getKey())));
+            m_correctReward[el->getKey()] = spVALUE(new VALUE(correctMiningReward.atKey(el->getKey())));
     }
     catch (std::exception const& _ex)
     {
@@ -253,7 +253,7 @@ void ClientConfig::performFieldReplace(DataObject& _data, FieldReplaceDir const&
     if (_data.type() == DataType::Object || _data.type() == DataType::Array)
     {
         for (auto& obj : _data.getSubObjectsUnsafe())
-            performFieldReplace(obj, _dir);
+            performFieldReplace(obj.getContent(), _dir);
     }
 }
 

--- a/retesteth/configs/ClientConfig.h
+++ b/retesteth/configs/ClientConfig.h
@@ -64,7 +64,7 @@ public:
     std::string const& translateException(string const& _exceptionName) const;
 
     // Get Contents of genesis template for specified FORK
-    DataObject const& getGenesisTemplate(FORK const& _fork) const;
+    spDataObject const& getGenesisTemplate(FORK const& _fork) const;
 
     // Get reward information info for each fork
     std::map<FORK, spVALUE> const& getRewardMap() const { return m_correctReward; }
@@ -85,7 +85,7 @@ private:
     ClientConfigID m_id;                                ///< Internal id
     GCP_SPointer<ClientConfigFile> m_clientConfigFile;  ///< <clientname>/config file
     std::map<FORK, spVALUE> m_correctReward;            ///< Correct mining reward info for StateTests->BlockchainTests
-    std::map<FORK, DataObject> m_genesisTemplate;       ///< Template For test_setChainParams
+    std::map<FORK, spDataObject> m_genesisTemplate;       ///< Template For test_setChainParams
     fs::path m_correctMiningRewardPath;                 ///< Path to correct mining reward info file
 
     bool m_initialized = false;    ///< If setup script has run

--- a/retesteth/configs/clientconfigs/aleth.cpp
+++ b/retesteth/configs/clientconfigs/aleth.cpp
@@ -72,15 +72,15 @@ killall aleth
 alethcfg::alethcfg()
 {
     {
-        DataObject obj;
-        obj["path"] = "aleth/config";
-        obj["content"] = aleth_config;
+        spDataObject obj(new DataObject());
+        (*obj)["path"] = "aleth/config";
+        (*obj)["content"] = aleth_config;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["path"] = "aleth/aleth.sh";
-        obj["content"] = aleth_config_sh;
+        spDataObject obj(new DataObject());
+        (*obj)["path"] = "aleth/aleth.sh";
+        (*obj)["content"] = aleth_config_sh;
         map_configs.addArrayObject(obj);
     }
     /*{
@@ -90,10 +90,10 @@ alethcfg::alethcfg()
         map_configs.addArrayObject(obj);
     }*/
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "aleth/stop.sh";
-        obj["content"] = aleth_stop_sh;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "aleth/stop.sh";
+        (*obj)["content"] = aleth_stop_sh;
         map_configs.addArrayObject(obj);
     }
 }

--- a/retesteth/configs/clientconfigs/alethIPCDebug.cpp
+++ b/retesteth/configs/clientconfigs/alethIPCDebug.cpp
@@ -46,8 +46,8 @@ string const alethIPCDebug_config = R"({
 
 alethIpcDebugcfg::alethIpcDebugcfg()
 {
-    DataObject obj;
-    obj["path"] = "alethIPCDebug/config";
-    obj["content"] = alethIPCDebug_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "alethIPCDebug/config";
+    (*obj)["content"] = alethIPCDebug_config;
     map_configs.addArrayObject(obj);
 }

--- a/retesteth/configs/clientconfigs/besu.cpp
+++ b/retesteth/configs/clientconfigs/besu.cpp
@@ -66,23 +66,23 @@ killall -9 java
 besucfg::besucfg()
 {
     {
-        DataObject obj;
-        obj["path"] = "besu/config";
-        obj["content"] = besu_config;
+        spDataObject obj(new DataObject());
+        (*obj)["path"] = "besu/config";
+        (*obj)["content"] = besu_config;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "besu/start.sh";
-        obj["content"] = besu_start;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "besu/start.sh";
+        (*obj)["content"] = besu_start;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "besu/stop.sh";
-        obj["content"] = besu_stop;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "besu/stop.sh";
+        (*obj)["content"] = besu_stop;
         map_configs.addArrayObject(obj);
     }
 }

--- a/retesteth/configs/clientconfigs/oewrap.cpp
+++ b/retesteth/configs/clientconfigs/oewrap.cpp
@@ -490,37 +490,37 @@ fi
 oewrapcfg::oewrapcfg()
 {
     {
-        DataObject obj;
-        obj["path"] = "oewrap/config";
-        obj["content"] = oewrap_config;
+        spDataObject obj(new DataObject());
+        (*obj)["path"] = "oewrap/config";
+        (*obj)["content"] = oewrap_config;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "oewrap/setup.sh";
-        obj["content"] = oewrap_setup;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "oewrap/setup.sh";
+        (*obj)["content"] = oewrap_setup;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "oewrap/start.sh";
-        obj["content"] = oewrap_start;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "oewrap/start.sh";
+        (*obj)["content"] = oewrap_start;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "oewrap/t8n_oe.js";
-        obj["content"] = oewrap_wrapper;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "oewrap/t8n_oe.js";
+        (*obj)["content"] = oewrap_wrapper;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = false;
-        obj["path"] = "oewrap/package.json";
-        obj["content"] = oewrap_package;
+        spDataObject obj(new DataObject());
+        (*obj)["exec"] = false;
+        (*obj)["path"] = "oewrap/package.json";
+        (*obj)["content"] = oewrap_package;
         map_configs.addArrayObject(obj);
     }
 }

--- a/retesteth/configs/clientconfigs/t8ntool.cpp
+++ b/retesteth/configs/clientconfigs/t8ntool.cpp
@@ -178,29 +178,29 @@ fi
 t8ntoolcfg::t8ntoolcfg()
 {
     {
-        DataObject obj;
-        obj["path"] = "t8ntool/config";
-        obj["content"] = t8ntool_config;
+        spDataObject obj = spDataObject(new DataObject());
+        (*obj)["path"] = "t8ntool/config";
+        (*obj)["content"] = t8ntool_config;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "t8ntool/start.sh";
-        obj["content"] = t8ntool_start;
+        spDataObject obj = spDataObject(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "t8ntool/start.sh";
+        (*obj)["content"] = t8ntool_start;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["path"] = "default/config";
-        obj["content"] = t8ntool_config;
+        spDataObject obj = spDataObject(new DataObject());
+        (*obj)["path"] = "default/config";
+        (*obj)["content"] = t8ntool_config;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["exec"] = true;
-        obj["path"] = "default/start.sh";
-        obj["content"] = t8ntool_start;
+        spDataObject obj = spDataObject(new DataObject());
+        (*obj)["exec"] = true;
+        (*obj)["path"] = "default/start.sh";
+        (*obj)["content"] = t8ntool_start;
         map_configs.addArrayObject(obj);
     }
 }

--- a/retesteth/configs/genesis/default/Berlin.cpp
+++ b/retesteth/configs/genesis/default/Berlin.cpp
@@ -32,13 +32,13 @@ const string t8ntool_Berlin_config = R"({
 
 genBerlinCfg::genBerlinCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/Berlin.json";
-    obj["content"] = default_Berlin_config;
+    spDataObject obj (new DataObject());
+    (*obj)["path"] = "besu/genesis/Berlin.json";
+    (*obj)["content"] = default_Berlin_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/Berlin.json";
-    obj2["content"] = t8ntool_Berlin_config;
+    spDataObject obj2 (new DataObject());
+    (*obj2)["path"] = "default/genesis/Berlin.json";
+    (*obj2)["content"] = t8ntool_Berlin_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/BerlinToLondonAt5.cpp
+++ b/retesteth/configs/genesis/default/BerlinToLondonAt5.cpp
@@ -33,15 +33,15 @@ const string t8ntool_BerlinToLondonAt5_config = R"({
 genBerlinToLondonCfg::genBerlinToLondonCfg()
 {
     {
-        DataObject obj;
-        obj["path"] = "besu/genesis/BerlinToLondonAt5.json";
-        obj["content"] = default_BerlinToLondonAt5_config;
+        spDataObject obj(new DataObject());
+        (*obj)["path"] = "besu/genesis/BerlinToLondonAt5.json";
+        (*obj)["content"] = default_BerlinToLondonAt5_config;
         map_configs.addArrayObject(obj);
     }
     {
-        DataObject obj;
-        obj["path"] = "default/genesis/BerlinToLondonAt5.json";
-        obj["content"] = t8ntool_BerlinToLondonAt5_config;
+        spDataObject obj(new DataObject());
+        (*obj)["path"] = "default/genesis/BerlinToLondonAt5.json";
+        (*obj)["content"] = t8ntool_BerlinToLondonAt5_config;
         map_configs.addArrayObject(obj);
     }
 }

--- a/retesteth/configs/genesis/default/Byzantium.cpp
+++ b/retesteth/configs/genesis/default/Byzantium.cpp
@@ -26,13 +26,13 @@ const string t8ntool_Byzantium_config = R"({
 
 genByzantiumCfg::genByzantiumCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/Byzantium.json";
-    obj["content"] = default_Byzantium_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/Byzantium.json";
+    (*obj)["content"] = default_Byzantium_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/Byzantium.json";
-    obj2["content"] = t8ntool_Byzantium_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/Byzantium.json";
+    (*obj2)["content"] = t8ntool_Byzantium_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/ByzantiumToConstantinopleFixAt5.cpp
+++ b/retesteth/configs/genesis/default/ByzantiumToConstantinopleFixAt5.cpp
@@ -29,13 +29,13 @@ const string t8ntool_ByzantiumToConstantinopleFixAt5_config = R"({
 
 genByzantiumToConstantinopleFixCfg::genByzantiumToConstantinopleFixCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/ByzantiumToConstantinopleFixAt5.json";
-    obj["content"] = default_ByzantiumToConstantinopleFixAt5_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/ByzantiumToConstantinopleFixAt5.json";
+    (*obj)["content"] = default_ByzantiumToConstantinopleFixAt5_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/ByzantiumToConstantinopleFixAt5.json";
-    obj2["content"] = t8ntool_ByzantiumToConstantinopleFixAt5_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/ByzantiumToConstantinopleFixAt5.json";
+    (*obj2)["content"] = t8ntool_ByzantiumToConstantinopleFixAt5_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/Constantinople.cpp
+++ b/retesteth/configs/genesis/default/Constantinople.cpp
@@ -28,14 +28,14 @@ const string t8ntool_Constantinople_config = R"({
 
 genConstantinopleCfg::genConstantinopleCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/Constantinople.json";
-    obj["content"] = default_Constantinople_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/Constantinople.json";
+    (*obj)["content"] = default_Constantinople_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/Constantinople.json";
-    obj2["content"] = t8ntool_Constantinople_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/Constantinople.json";
+    (*obj2)["content"] = t8ntool_Constantinople_config;
     map_configs.addArrayObject(obj2);
 }
 

--- a/retesteth/configs/genesis/default/ConstantinopleFix.cpp
+++ b/retesteth/configs/genesis/default/ConstantinopleFix.cpp
@@ -29,13 +29,13 @@ const string t8ntool_ConstantinopleFix_config = R"({
 
 genConstantinopleFixCfg::genConstantinopleFixCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/ConstantinopleFix.json";
-    obj["content"] = default_ConstantinopleFix_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/ConstantinopleFix.json";
+    (*obj)["content"] = default_ConstantinopleFix_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/ConstantinopleFix.json";
-    obj2["content"] = t8ntool_ConstantinopleFix_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/ConstantinopleFix.json";
+    (*obj2)["content"] = t8ntool_ConstantinopleFix_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/EIP150.cpp
+++ b/retesteth/configs/genesis/default/EIP150.cpp
@@ -23,13 +23,13 @@ const string t8ntool_EIP150_config = R"({
 
 genEIP150Cfg::genEIP150Cfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/EIP150.json";
-    obj["content"] = default_EIP150_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/EIP150.json";
+    (*obj)["content"] = default_EIP150_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/EIP150.json";
-    obj2["content"] = t8ntool_EIP150_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/EIP150.json";
+    (*obj2)["content"] = t8ntool_EIP150_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/EIP158.cpp
+++ b/retesteth/configs/genesis/default/EIP158.cpp
@@ -24,13 +24,13 @@ const string t8ntool_EIP158_config = R"({
 
 genEIP158Cfg::genEIP158Cfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/EIP158.json";
-    obj["content"] = default_EIP158_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/EIP158.json";
+    (*obj)["content"] = default_EIP158_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/EIP158.json";
-    obj2["content"] = t8ntool_EIP158_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/EIP158.json";
+    (*obj2)["content"] = t8ntool_EIP158_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/EIP158ToByzantiumAt5.cpp
+++ b/retesteth/configs/genesis/default/EIP158ToByzantiumAt5.cpp
@@ -26,13 +26,13 @@ const string t8ntool_EIP158ToByzantiumAt5_config = R"({
 
 genEIP158ToByzantiumCfg::genEIP158ToByzantiumCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/EIP158ToByzantiumAt5.json";
-    obj["content"] = default_EIP158ToByzantiumAt5_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/EIP158ToByzantiumAt5.json";
+    (*obj)["content"] = default_EIP158ToByzantiumAt5_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/EIP158ToByzantiumAt5.json";
-    obj2["content"] = t8ntool_EIP158ToByzantiumAt5_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/EIP158ToByzantiumAt5.json";
+    (*obj2)["content"] = t8ntool_EIP158ToByzantiumAt5_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/Frontier.cpp
+++ b/retesteth/configs/genesis/default/Frontier.cpp
@@ -20,14 +20,14 @@ const string t8ntool_Frontier_config = R"({
 
 genFrontierCfg::genFrontierCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/Frontier.json";
-    obj["content"] = default_Frontier_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/Frontier.json";
+    (*obj)["content"] = default_Frontier_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/Frontier.json";
-    obj2["content"] = t8ntool_Frontier_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/Frontier.json";
+    (*obj2)["content"] = t8ntool_Frontier_config;
     map_configs.addArrayObject(obj2);
 }
 

--- a/retesteth/configs/genesis/default/FrontierToHomesteadAt5.cpp
+++ b/retesteth/configs/genesis/default/FrontierToHomesteadAt5.cpp
@@ -22,13 +22,13 @@ const string t8ntool_FrontierToHomesteadAt5_config = R"({
 
 genFrontierToHomesteadCfg::genFrontierToHomesteadCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/FrontierToHomesteadAt5.json";
-    obj["content"] = default_FrontierToHomesteadAt5_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/FrontierToHomesteadAt5.json";
+    (*obj)["content"] = default_FrontierToHomesteadAt5_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/FrontierToHomesteadAt5.json";
-    obj2["content"] = t8ntool_FrontierToHomesteadAt5_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/FrontierToHomesteadAt5.json";
+    (*obj2)["content"] = t8ntool_FrontierToHomesteadAt5_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/Homestead.cpp
+++ b/retesteth/configs/genesis/default/Homestead.cpp
@@ -22,13 +22,13 @@ const string t8ntool_Homestead_config = R"({
 
 genHomesteadCfg::genHomesteadCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/Homestead.json";
-    obj["content"] = default_Homestead_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/Homestead.json";
+    (*obj)["content"] = default_Homestead_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/Homestead.json";
-    obj2["content"] = t8ntool_Homestead_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/Homestead.json";
+    (*obj2)["content"] = t8ntool_Homestead_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/HomesteadToDaoAt5.cpp
+++ b/retesteth/configs/genesis/default/HomesteadToDaoAt5.cpp
@@ -23,13 +23,13 @@ const string t8ntool_HomesteadToDaoAt5_config = R"({
 
 genHomesteadToDaoCfg::genHomesteadToDaoCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/HomesteadToDaoAt5.json";
-    obj["content"] = default_HomesteadToDaoAt5_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/HomesteadToDaoAt5.json";
+    (*obj)["content"] = default_HomesteadToDaoAt5_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/HomesteadToDaoAt5.json";
-    obj2["content"] = t8ntool_HomesteadToDaoAt5_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/HomesteadToDaoAt5.json";
+    (*obj2)["content"] = t8ntool_HomesteadToDaoAt5_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/HomesteadToEIP150At5.cpp
+++ b/retesteth/configs/genesis/default/HomesteadToEIP150At5.cpp
@@ -23,13 +23,13 @@ const string t8ntool_HomesteadToEIP150At5_config = R"({
 
 genHomesteadToEIP150Cfg::genHomesteadToEIP150Cfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/HomesteadToEIP150At5.json";
-    obj["content"] = default_HomesteadToEIP150At5_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/HomesteadToEIP150At5.json";
+    (*obj)["content"] = default_HomesteadToEIP150At5_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/HomesteadToEIP150At5.json";
-    obj2["content"] = t8ntool_HomesteadToEIP150At5_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/HomesteadToEIP150At5.json";
+    (*obj2)["content"] = t8ntool_HomesteadToEIP150At5_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/Istanbul.cpp
+++ b/retesteth/configs/genesis/default/Istanbul.cpp
@@ -31,13 +31,13 @@ const string t8ntool_Istanbul_config = R"({
 
 genIstanbulCfg::genIstanbulCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/Istanbul.json";
-    obj["content"] = default_Istanbul_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/Istanbul.json";
+    (*obj)["content"] = default_Istanbul_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/Istanbul.json";
-    obj2["content"] = t8ntool_Istanbul_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/Istanbul.json";
+    (*obj2)["content"] = t8ntool_Istanbul_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/London.cpp
+++ b/retesteth/configs/genesis/default/London.cpp
@@ -33,13 +33,13 @@ const string t8ntool_London_config = R"({
 
 genLondonCfg::genLondonCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/London.json";
-    obj["content"] = default_London_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/London.json";
+    (*obj)["content"] = default_London_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/London.json";
-    obj2["content"] = t8ntool_London_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/London.json";
+    (*obj2)["content"] = t8ntool_London_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/configs/genesis/default/correctMiningReward.cpp
+++ b/retesteth/configs/genesis/default/correctMiningReward.cpp
@@ -39,13 +39,13 @@ const string t8ntool_correctMiningReward_config = R"({
 
 genRewardsCfg::genRewardsCfg()
 {
-    DataObject obj;
-    obj["path"] = "besu/genesis/correctMiningReward.json";
-    obj["content"] = default_correctMiningReward_config;
+    spDataObject obj(new DataObject());
+    (*obj)["path"] = "besu/genesis/correctMiningReward.json";
+    (*obj)["content"] = default_correctMiningReward_config;
     map_configs.addArrayObject(obj);
 
-    DataObject obj2;
-    obj2["path"] = "default/genesis/correctMiningReward.json";
-    obj2["content"] = t8ntool_correctMiningReward_config;
+    spDataObject obj2(new DataObject());
+    (*obj2)["path"] = "default/genesis/correctMiningReward.json";
+    (*obj2)["content"] = t8ntool_correctMiningReward_config;
     map_configs.addArrayObject(obj2);
 }

--- a/retesteth/dataObject/ConvertFile.cpp
+++ b/retesteth/dataObject/ConvertFile.cpp
@@ -133,16 +133,16 @@ bool checkExcessiveComa(string const& _input, size_t _i)
 }
 
 /// Convert Json object represented as string to DataObject
-DataObject ConvertJsoncppStringToData(
+spDataObject ConvertJsoncppStringToData(
     std::string const& _input, string const& _stopper, bool _autosort)
 {
     if (_input.size() < 2 || _input.find("{") == string::npos || _input.find("}") == string::npos)
         throw DataObjectException() << "ConvertJsoncppStringToData can't read json structure in file: `" + _input.substr(0, 50);
 
     std::vector<DataObject*> applyDepth;  // indexes at root array of objects that we are reading into
-    DataObject root;
-    root.setAutosort(_autosort);
-    DataObject* actualRoot = &root;
+    spDataObject root(new DataObject());
+    root.getContent().setAutosort(_autosort);
+    DataObject* actualRoot = &root.getContent();
     bool keyEncountered = false;
 
     auto printDebug = [&_input](int _i) {
@@ -166,8 +166,8 @@ DataObject ConvertJsoncppStringToData(
         bool escapeChar = (i > 0 && _input[i - 1] == '\\');
         if (_input[i] == '"' && !escapeChar)
         {
-            DataObject obj;
-            string key = parseKeyValue(_input, i);
+            spDataObject obj(new DataObject());
+            string const key = parseKeyValue(_input, i);
             i = stripSpaces(_input, i);
             if (_input.at(i) == ':')
             {
@@ -179,7 +179,7 @@ DataObject ConvertJsoncppStringToData(
                 if (actualRoot->type() == DataType::Array)
                     throw DataObjectException()
                         << errorPrefix + "array could not have elements with keys! around: " + printDebug(i);
-                obj.setKey(key);
+                (*obj).setKey(key);
                 bool replaceKey = false;
                 size_t keyPosExpected = _autosort ?
                                             max(0, (int)findOrderedKeyPosition(key, actualRoot->getSubObjects()) - 1) : 0;
@@ -207,7 +207,7 @@ DataObject ConvertJsoncppStringToData(
                 keyEncountered = false;
                 if (actualRoot->type() == DataType::Array)
                 {
-                    actualRoot->addArrayObject(DataObject(key));
+                    actualRoot->addArrayObject(spDataObject(new DataObject(key)));
                     if (_input.at(i) != ',')
                         i--;  // because cycle iteration we need to process ending clouse
                     continue;
@@ -227,14 +227,14 @@ DataObject ConvertJsoncppStringToData(
         {
             if (actualRoot->type() == DataType::Array || actualRoot->type() == DataType::Object)
             {
-                DataObject newObj(DataType::Object);
+                spDataObject newObj(new DataObject(DataType::Object));
                 applyDepth.push_back(actualRoot);
                 actualRoot = &actualRoot->addSubObject(newObj);
                 // actualRoot->setAutosort(_autosort);
                 continue;
             }
 
-            actualRoot->addSubObject(DataObject());
+            actualRoot->addSubObject(spDataObject(new DataObject()));
             actualRoot->getSubObjectsUnsafe().pop_back();
             continue;
         }
@@ -242,8 +242,8 @@ DataObject ConvertJsoncppStringToData(
         {
             if (actualRoot->type() == DataType::Array || actualRoot->type() == DataType::Object)
             {
-                DataObject newObj(DataType::Array);
-                newObj.setAutosort(_autosort);
+                spDataObject newObj(new DataObject(DataType::Array));
+                (*newObj).setAutosort(_autosort);
                 applyDepth.push_back(actualRoot);
                 actualRoot = &actualRoot->addSubObject(newObj);
 
@@ -252,7 +252,7 @@ DataObject ConvertJsoncppStringToData(
                 continue;
             }
 
-            actualRoot->addArrayObject(DataObject());
+            actualRoot->addArrayObject(spDataObject(new DataObject()));
             actualRoot->getSubObjectsUnsafe().pop_back();
             continue;
         }
@@ -319,11 +319,11 @@ DataObject ConvertJsoncppStringToData(
             if (actualRoot->type() == DataType::Array)
             {
                 if (isReadDigit)
-                    actualRoot->addArrayObject(DataObject(resInt));
+                    actualRoot->addArrayObject(spDataObject(new DataObject(resInt)));
                 else if (isReadBool)
-                    actualRoot->addArrayObject(DataObject(DataType::Bool, resBool));
+                    actualRoot->addArrayObject(spDataObject(new DataObject(DataType::Bool, resBool)));
                 else
-                    actualRoot->addArrayObject(DataObject(DataType::Null));
+                    actualRoot->addArrayObject(spDataObject(new DataObject(DataType::Null)));
             }
             else
             {

--- a/retesteth/dataObject/ConvertFile.cpp
+++ b/retesteth/dataObject/ConvertFile.cpp
@@ -182,14 +182,14 @@ DataObject ConvertJsoncppStringToData(
                 obj.setKey(key);
                 bool replaceKey = false;
                 size_t keyPosExpected = _autosort ?
-                        max(0, (int)findOrderedKeyPosition(key, actualRoot->getSubObjects()) - 1) : 0;
+                                            max(0, (int)findOrderedKeyPosition(key, actualRoot->getSubObjects()) - 1) : 0;
                 for (size_t objI = keyPosExpected; objI < actualRoot->getSubObjects().size(); objI++)
                 {
-                    if (actualRoot->getSubObjects().at(objI).getKey() == key)
+                    if (actualRoot->getSubObjects().at(objI)->getKey() == key)
                     {
                         replaceKey = true;
                         applyDepth.push_back(actualRoot);
-                        actualRoot = &actualRoot->getSubObjectsUnsafe().at(objI);
+                        actualRoot = &actualRoot->getSubObjectsUnsafe().at(objI).getContent();
                         actualRoot->clearSubobjects();
                         break;
                     }

--- a/retesteth/dataObject/ConvertFile.cpp
+++ b/retesteth/dataObject/ConvertFile.cpp
@@ -163,8 +163,8 @@ spDataObject ConvertJsoncppStringToData(
         if (i == _input.length())
             throw DataObjectException() << errorPrefix + "unexpected end of json! around: " + printDebug(i);
 
-        bool escapeChar = (i > 0 && _input[i - 1] == '\\');
-        if (_input[i] == '"' && !escapeChar)
+        bool escapeChar = (i > 0 && _input.at(i - 1) == '\\');
+        if (_input.at(i) == '"' && !escapeChar)
         {
             spDataObject obj(new DataObject());
             string const key = parseKeyValue(_input, i);
@@ -223,7 +223,7 @@ spDataObject ConvertJsoncppStringToData(
         }
 
         keyEncountered = false;
-        if (_input[i] == '{')
+        if (_input.at(i) == '{')
         {
             if (actualRoot->type() == DataType::Array || actualRoot->type() == DataType::Object)
             {
@@ -238,7 +238,7 @@ spDataObject ConvertJsoncppStringToData(
             actualRoot->getSubObjectsUnsafe().pop_back();
             continue;
         }
-        if (_input[i] == '[')
+        if (_input.at(i) == '[')
         {
             if (actualRoot->type() == DataType::Array || actualRoot->type() == DataType::Object)
             {
@@ -257,7 +257,7 @@ spDataObject ConvertJsoncppStringToData(
             continue;
         }
 
-        if (_input[i] == ']' || _input[i] == '}')
+        if (_input.at(i) == ']' || _input.at(i) == '}')
         {
             // if (actualRoot->type() == DataType::Null)
             //    throw DataObjectException()
@@ -288,12 +288,12 @@ spDataObject ConvertJsoncppStringToData(
 
                 if (i + 1 < _input.length())
                 {
-                    if (_input[i + 1] == ',')
+                    if (_input.at(i + 1) == ',')
                     {
                         i++;
                         continue;
                     }
-                    if (_input[i + 1] == ':')
+                    if (_input.at(i + 1) == ':')
                         throw DataObjectException()
                             << errorPrefix + "unexpected ':' after closing an object/array! around: " + printDebug(i);
                 }
@@ -336,7 +336,7 @@ spDataObject ConvertJsoncppStringToData(
                 actualRoot = applyDepth.at(applyDepth.size() - 1);
                 applyDepth.pop_back();
             }
-            if (_input[i] != ',')
+            if (_input.at(i) != ',')
                 i--;
             continue;
         }

--- a/retesteth/dataObject/ConvertFile.h
+++ b/retesteth/dataObject/ConvertFile.h
@@ -4,6 +4,6 @@
 namespace dataobject
 {
 /// Convert Json object represented as string to DataObject
-DataObject ConvertJsoncppStringToData(
+spDataObject ConvertJsoncppStringToData(
     std::string const& _input, string const& _stopper = string(), bool _setAutosort = false);
 }

--- a/retesteth/dataObject/ConvertYaml.cpp
+++ b/retesteth/dataObject/ConvertYaml.cpp
@@ -25,40 +25,40 @@ std::string yamlTypeAsString(YAML::NodeType::value _type)
     return "";
 }
 
-DataObject ConvertYamlToData(YAML::Node const& _node)
+spDataObject ConvertYamlToData(YAML::Node const& _node)
 {
     if (_node.IsNull())
-        return DataObject(DataType::Null);
+        return spDataObject(new DataObject(DataType::Null));
 
     if (_node.IsScalar())
     {
         if (_node.Tag() == "tag:yaml.org,2002:int")
-            return DataObject(_node.as<int>());
+            return spDataObject(new DataObject(_node.as<int>()));
         else
-            return DataObject(_node.as<string>());
+            return spDataObject(new DataObject(_node.as<string>()));
     }
 
     if (_node.IsMap())
     {
-        DataObject jObject(DataType::Object);
-        jObject.setAutosort(true);
+        spDataObject jObject(new DataObject(DataType::Object));
+        (*jObject).setAutosort(true);
         for (auto const& i : _node)
-            jObject.addSubObject(i.first.as<string>(), ConvertYamlToData(i.second));
+            (*jObject).addSubObject(i.first.as<string>(), ConvertYamlToData(i.second));
         return jObject;
     }
 
     if (_node.IsSequence())
     {
-        DataObject jArray(DataType::Array);
-        jArray.setAutosort(true);
+        spDataObject jArray(new DataObject(DataType::Array));
+        (*jArray).setAutosort(true);
         for (size_t i = 0; i < _node.size(); i++)
-            jArray.addArrayObject(ConvertYamlToData(_node[i]));
+            (*jArray).addArrayObject(ConvertYamlToData(_node[i]));
         return jArray;
     }
 
     // Make it an exception!
     std::cerr << "Error parsing YAML node. Element type not defined! " + yamlTypeAsString(_node.Type());
-    return DataObject(DataType::Null);
+    return spDataObject(new DataObject(DataType::Null));
 }
 
 }//namespace

--- a/retesteth/dataObject/ConvertYaml.h
+++ b/retesteth/dataObject/ConvertYaml.h
@@ -7,5 +7,5 @@ namespace dataobject
 std::string yamlTypeAsString(YAML::NodeType::value _type);
 
 /// Convert Yaml object to DataObject
-DataObject ConvertYamlToData(YAML::Node const& _input);
+spDataObject ConvertYamlToData(YAML::Node const& _input);
 }

--- a/retesteth/dataObject/DataObject.cpp
+++ b/retesteth/dataObject/DataObject.cpp
@@ -70,13 +70,13 @@ std::string const& DataObject::getKey() const
 }
 
 /// Get vector of subobjects
-std::vector<DataObject> const& DataObject::getSubObjects() const
+std::vector<spDataObject> const& DataObject::getSubObjects() const
 {
     return m_subObjects;
 }
 
 /// Get ref vector of subobjects
-std::vector<DataObject>& DataObject::getSubObjectsUnsafe()
+std::vector<spDataObject>& DataObject::getSubObjectsUnsafe()
 {
     return m_subObjects;
 }
@@ -678,6 +678,9 @@ DataObject& DataObject::operator[](std::string const& _key)
 {
     _assert(m_type == DataType::NotInitialized || m_type == DataType::Object,
         "m_type == DataType::NotInitialized || m_type == DataType::Object (DataObject& operator[])");
+
+    if (m_subObjectKeys.count(_key))
+        return m_subObjectKeys.at(_key).getContent();
 
     auto res =
         std::find_if(m_subObjects.begin(), m_subObjects.end(), [&_key](DataObject const& x)

--- a/retesteth/dataObject/DataObject.cpp
+++ b/retesteth/dataObject/DataObject.cpp
@@ -5,70 +5,53 @@
 using namespace dataobject;
 
 /// Default dataobject is null
-DataObject::DataObject()
-{
-    m_type = DataType::NotInitialized;
-}
+DataObject::DataObject() { m_type = DataType::NotInitialized; }
 
 /// Define dataobject of _type, pass the value later (will check the value and _type)
-DataObject::DataObject(DataType _type)
-{
-    m_type = _type;
-}
+DataObject::DataObject(DataType _type) { m_type = _type; }
 
 /// Define dataobject of string
 DataObject::DataObject(std::string const& _str)
+  : m_strVal(_str)
 {
     m_type = DataType::String;
-    m_strVal = _str;
 }
 
 /// Define dataobject[_key] = string
 DataObject::DataObject(std::string const& _key, std::string const& _str)
+  : m_strKey(_key), m_strVal(_str)
 {
     m_type = DataType::String;
-    m_strVal = _str;
-    m_strKey = _key;
 }
 
 DataObject::DataObject(std::string const& _key, int _val)
+ : m_strKey(_key), m_intVal(_val)
 {
     m_type = DataType::Integer;
-    m_intVal = _val;
-    m_strKey = _key;
 }
 
 /// Define dataobject of int
 DataObject::DataObject(int _int)
+  : m_intVal(_int)
 {
     m_type = DataType::Integer;
-    m_intVal = _int;
 }
 
 /// Define dataobject of bool
 DataObject::DataObject(DataType type, bool _bool)
+  : m_boolVal(_bool)
 {
     m_type = type;
-    m_boolVal = _bool;
 }
 
 /// Get dataobject type
-DataType DataObject::type() const
-{
-    return m_type;
-}
+DataType DataObject::type() const { return m_type; }
 
 /// Set key of the dataobject
-void DataObject::setKey(std::string const& _key)
-{
-    m_strKey = _key;
-}
+void DataObject::setKey(std::string const& _key) { m_strKey = _key; }
 
 /// Get key of the dataobject
-std::string const& DataObject::getKey() const
-{
-    return m_strKey;
-}
+std::string const& DataObject::getKey() const { return m_strKey; }
 
 /// Get vector of subobjects
 std::vector<spDataObject> const& DataObject::getSubObjects() const

--- a/retesteth/dataObject/DataObject.cpp
+++ b/retesteth/dataObject/DataObject.cpp
@@ -1,6 +1,7 @@
 #include <dataObject/DataObject.h>
 #include <algorithm>
 #include <sstream>
+#include <iostream>
 using namespace dataobject;
 
 /// Default dataobject is null
@@ -190,13 +191,31 @@ void DataObject::replace(DataObject const& _value)
     setAutosort(_value.isAutosort());
 }
 
-spDataObject DataObject::atKeyPointer(std::string const& _key)
+DataObjectK& DataObjectK::operator=(spDataObject const& _value)
+{
+    if (m_data.count(m_key))
+    {
+        m_data.removeKey(m_key);
+        if(_value.getCContent().getKey().empty())
+            throw DataObjectException("DataObjectK::operator=(spDataObject const& _value)  _value without key, but key required!");
+        m_data.addSubObject(_value.getCContent().getKey(), _value);
+    }
+    else
+        m_data.addSubObject(m_key, _value);
+    return *this;
+}
+
+spDataObject DataObject::atKeyPointerUnsafe(std::string const& _key)
 {
     if (m_subObjectKeys.count(_key))
         return m_subObjectKeys.at(_key);
+    _assert(false, "count(_key) _key=" + _key + " (DataObject::atKeyPointerUnsafe)");
+    return spDataObject(0);
+}
 
-    _assert(false, "count(_key) _key=" + _key + " (DataObject::atKeyPointer)");
-    return m_subObjects.at(0);
+DataObjectK DataObject::atKeyPointer(std::string const& _key)
+{
+    return DataObjectK(_key, *this);
 }
 
 DataObject const& DataObject::atKey(std::string const& _key) const
@@ -308,6 +327,7 @@ void DataObject::clear(DataType _type)
     m_strKey = "";
     m_strVal = "";
     m_subObjects.clear();
+    m_subObjectKeys.clear();
     m_type = _type;
 }
 

--- a/retesteth/dataObject/DataObject.h
+++ b/retesteth/dataObject/DataObject.h
@@ -99,8 +99,6 @@ private:
 
     DataObject& _addSubObject(DataObject const& _obj, string const& _keyOverwrite = string());
     void _assert(bool _flag, std::string const& _comment = "") const;
-    vector<spDataObject>::const_iterator subByKey(string const& _key) const;
-    vector<spDataObject>::iterator subByKeyU(string const& _key);
 
     std::vector<spDataObject> m_subObjects;
     std::map<string, spDataObject> m_subObjectKeys;
@@ -119,5 +117,5 @@ private:
 typedef GCP_SPointer<DataObject> spDataObject;
 
 // Find index that _key should take place in when being added to ordered _objects by key
-size_t findOrderedKeyPosition(string const& _key, vector<DataObject> const& _objects);
+size_t findOrderedKeyPosition(string const& _key, vector<spDataObject> const& _objects);
 }

--- a/retesteth/dataObject/DataObject.h
+++ b/retesteth/dataObject/DataObject.h
@@ -19,6 +19,8 @@ enum DataType
     NotInitialized
 };
 
+class DataObjectK;
+
 /// DataObject
 /// A data sturcture to manage data from json, yml
 class DataObject : public GCP_SPointerBase
@@ -73,7 +75,8 @@ public:
     void removeKey(std::string const& _key);  // vector<element> erase method with `replace()` function
 
     DataObject const& atKey(std::string const& _key) const;
-    spDataObject atKeyPointer(std::string const& _key);
+    DataObjectK atKeyPointer(std::string const& _key);
+    spDataObject atKeyPointerUnsafe(std::string const& _key);
     DataObject& atKeyUnsafe(std::string const& _key);
     DataObject const& at(size_t _pos) const;
     DataObject& atUnsafe(size_t _pos);
@@ -121,6 +124,21 @@ private:
 };
 
 typedef GCP_SPointer<DataObject> spDataObject;
+
+// The key assigner
+class DataObjectK
+{
+public:
+    DataObjectK(string const& _key, DataObject& _container)
+      : m_key(_key), m_data(_container) {}
+    DataObjectK& operator=(spDataObject const& _value);
+    DataObject& getContent() { return m_data; }
+    operator spDataObject() { return m_data.atKeyPointerUnsafe(m_key); }
+
+private:
+    string m_key;
+    DataObject& m_data;
+};
 
 // Find index that _key should take place in when being added to ordered _objects by key
 size_t findOrderedKeyPosition(string const& _key, vector<spDataObject> const& _objects);

--- a/retesteth/dataObject/DataObject.h
+++ b/retesteth/dataObject/DataObject.h
@@ -26,7 +26,7 @@ class DataObject : public GCP_SPointerBase
 public:
     typedef GCP_SPointer<DataObject> spDataObject;
     DataObject();
-    DataObject(DataObject const&) = default;
+    DataObject(DataObject const&) = delete;
     DataObject(DataType _type);
     DataObject(DataType _type, bool _bool);
     DataObject(std::string const& _str);
@@ -39,11 +39,13 @@ public:
     std::string const& getKey() const;
 
     std::vector<spDataObject> const& getSubObjects() const;
+    std::map<string, spDataObject> const& getSubObjectKeys() const;
     std::vector<spDataObject>& getSubObjectsUnsafe();
 
-    void addArrayObject(DataObject const& _obj);
-    DataObject& addSubObject(DataObject const& _obj);
-    DataObject& addSubObject(std::string const& _key, DataObject const& _obj);
+    void addArrayObject(spDataObject const& _obj);
+    DataObject& addSubObject(spDataObject const& _obj);
+
+    DataObject& addSubObject(std::string const& _key, spDataObject const& _obj);
     void setSubObjectKey(size_t _index, std::string const& _key);
     void setKeyPos(std::string const& _key, size_t _pos);
 
@@ -56,7 +58,7 @@ public:
     bool operator==(bool _value) const;
     bool operator==(DataObject const& _value) const;
     DataObject& operator[](std::string const& _key);
-    DataObject& operator=(DataObject const& _value);
+    DataObject& operator=(DataObject const& _value) = delete;
     DataObject& operator=(std::string const& _value);
     DataObject& operator=(int _value);
 
@@ -97,7 +99,7 @@ public:
 
 private:
 
-    DataObject& _addSubObject(DataObject const& _obj, string const& _keyOverwrite = string());
+    DataObject& _addSubObject(spDataObject const& _obj, string const& _keyOverwrite = string());
     void _assert(bool _flag, std::string const& _comment = "") const;
 
     std::vector<spDataObject> m_subObjects;

--- a/retesteth/dataObject/DataObject.h
+++ b/retesteth/dataObject/DataObject.h
@@ -1,8 +1,10 @@
 #pragma once
 #include <dataObject/Exception.h>
+#include <dataObject/SPointer.h>
 #include <memory>
 #include <set>
 #include <vector>
+#include <map>
 
 namespace dataobject
 {
@@ -18,10 +20,11 @@ enum DataType
 };
 
 /// DataObject
-/// An data sturcture to manage data from json, yml
-class DataObject
+/// A data sturcture to manage data from json, yml
+class DataObject : public GCP_SPointerBase
 {
 public:
+    typedef GCP_SPointer<DataObject> spDataObject;
     DataObject();
     DataObject(DataObject const&) = default;
     DataObject(DataType _type);
@@ -35,8 +38,8 @@ public:
     void setKey(std::string const& _key);
     std::string const& getKey() const;
 
-    std::vector<DataObject> const& getSubObjects() const;
-    std::vector<DataObject>& getSubObjectsUnsafe();
+    std::vector<spDataObject> const& getSubObjects() const;
+    std::vector<spDataObject>& getSubObjectsUnsafe();
 
     void addArrayObject(DataObject const& _obj);
     DataObject& addSubObject(DataObject const& _obj);
@@ -88,16 +91,19 @@ public:
     void clearSubobjects(DataType _type = DataType::NotInitialized)
     {
         m_subObjects.clear();
+        m_subObjectKeys.clear();
         m_type = _type;
     }
 
 private:
+
     DataObject& _addSubObject(DataObject const& _obj, string const& _keyOverwrite = string());
     void _assert(bool _flag, std::string const& _comment = "") const;
-    vector<DataObject>::const_iterator subByKey(string const& _key) const;
-    vector<DataObject>::iterator subByKeyU(string const& _key);
+    vector<spDataObject>::const_iterator subByKey(string const& _key) const;
+    vector<spDataObject>::iterator subByKeyU(string const& _key);
 
-    std::vector<DataObject> m_subObjects;
+    std::vector<spDataObject> m_subObjects;
+    std::map<string, spDataObject> m_subObjectKeys;
     DataType m_type;
     std::string m_strKey;
     bool m_allowOverwrite = false;  // allow overwrite elements
@@ -109,6 +115,8 @@ private:
 
     void (*m_verifier)(DataObject&) = 0;
 };
+
+typedef GCP_SPointer<DataObject> spDataObject;
 
 // Find index that _key should take place in when being added to ordered _objects by key
 size_t findOrderedKeyPosition(string const& _key, vector<DataObject> const& _objects);

--- a/retesteth/dataObject/DataObject.h
+++ b/retesteth/dataObject/DataObject.h
@@ -59,6 +59,9 @@ public:
     bool operator==(DataObject const& _value) const;
     DataObject& operator[](std::string const& _key);
     DataObject& operator=(DataObject const& _value) = delete;
+    //DataObject& operator=(spDataObject const& _value);
+    spDataObject copy() const;
+    void copyFrom(DataObject const& _other);
     DataObject& operator=(std::string const& _value);
     DataObject& operator=(int _value);
 
@@ -70,6 +73,7 @@ public:
     void removeKey(std::string const& _key);  // vector<element> erase method with `replace()` function
 
     DataObject const& atKey(std::string const& _key) const;
+    spDataObject atKeyPointer(std::string const& _key);
     DataObject& atKeyUnsafe(std::string const& _key);
     DataObject const& at(size_t _pos) const;
     DataObject& atUnsafe(size_t _pos);

--- a/retesteth/dataObject/DataObjectScheme.h
+++ b/retesteth/dataObject/DataObjectScheme.h
@@ -34,7 +34,7 @@ public:
         };
         DataType dataTypeExpected;
         verification verificationType;
-        DataObject dataEnum;
+        spDataObject dataEnum;
     };
 
     std::vector<ValidationRule> const& getRules() { return rulesVector; }
@@ -71,8 +71,7 @@ private:
             if (_obj.atKey("enum").type() != DataType::Array)
                 throw DataObjectException() << "Validation scheme 'enum' field must be an array!";
             rule.verificationType = ValidationRule::verification::CHECK_EXACT;
-            rule.dataEnum =
-                _obj.atKey("enum").getSubObjects().at(0);  // enum with only 1 element!!!
+            rule.dataEnum = _obj.atKey("enum").getSubObjects().at(0);  // enum with only 1 element!!!
         }
 
         rulesVector.push_back(rule);

--- a/retesteth/dataObject/DataObjectValidator.h
+++ b/retesteth/dataObject/DataObjectValidator.h
@@ -82,7 +82,7 @@ private:
                 bool found = false;
                 for (auto const& element2 : _object.getSubObjects())
                 {
-                    if (element.type() == element2.type() && element.getKey() == element2.getKey())
+                    if (element->type() == element2->type() && element->getKey() == element2->getKey())
                     {
                         found = true;
                         checkExactValue(element2, element);
@@ -90,7 +90,7 @@ private:
                     }
                 }
                 if (!found)
-                    throw ExpectedButGot("Array elelemnt '" + element.asJson() + "'",
+                    throw ExpectedButGot("Array elelemnt '" + element->asJson() + "'",
                         " no elements like this in " + _object.asJson(), false);
             }
 

--- a/retesteth/dataObject/SPointer.cpp
+++ b/retesteth/dataObject/SPointer.cpp
@@ -12,18 +12,17 @@ void throwException(std::string const& _ex)
     throw SPointerException(_ex);
 }
 
-std::mutex g_spMutexAdd;
-std::mutex g_spMutexDel;
-
-
+//std::mutex g_spMutexAdd;
+//std::mutex g_spMutexDel;
 void GCP_SPointerBase::AddRef()
 {
-    std::lock_guard<std::mutex> lock(g_spMutexAdd);
+    // very heavy. use thread unsafe pointer preferably
+    //std::lock_guard<std::mutex> lock(g_spMutexAdd);
     _nRef++;
 }
 int GCP_SPointerBase::DelRef()
 {
-    std::lock_guard<std::mutex> lock(g_spMutexDel);
+    //std::lock_guard<std::mutex> lock(g_spMutexDel);
     _nRef--;
     return _nRef;
 }

--- a/retesteth/dataObject/SPointer.cpp
+++ b/retesteth/dataObject/SPointer.cpp
@@ -1,12 +1,31 @@
 #include "SPointer.h"
 #include <string>
+#include <mutex>
+
 
 namespace dataobject
 {
+
 // To debug exceptions as breakpoints does not work from header
 void throwException(std::string const& _ex)
 {
     throw SPointerException(_ex);
+}
+
+std::mutex g_spMutexAdd;
+std::mutex g_spMutexDel;
+
+
+void GCP_SPointerBase::AddRef()
+{
+    std::lock_guard<std::mutex> lock(g_spMutexAdd);
+    _nRef++;
+}
+int GCP_SPointerBase::DelRef()
+{
+    std::lock_guard<std::mutex> lock(g_spMutexDel);
+    _nRef--;
+    return _nRef;
 }
 
 }  // namespace dataobject

--- a/retesteth/dataObject/SPointer.h
+++ b/retesteth/dataObject/SPointer.h
@@ -181,6 +181,11 @@ public:
         return getCPtr();
     }
 
+    template<class Tb, class Ta>
+    Tb operator[] (Ta arg){
+        return _pointee[arg];
+    }
+
     // T* operator->() const { return _pointee; }
     // operator T*() { return _pointee; }
     // operator GCP_SPointer<T>() { return GCP_SPointer<T>(this); }

--- a/retesteth/dataObject/SPointer.h
+++ b/retesteth/dataObject/SPointer.h
@@ -178,10 +178,10 @@ public:
         return getCPtr();
     }
 
-    template<class Tb, class Ta>
-    Tb operator[] (Ta arg){
-        return _pointee[arg];
-    }
+    //template<class Tb, class Ta>
+    //Tb operator[] (Ta arg){
+    //    return _pointee[arg];
+   // }
 
     // T* operator->() const { return _pointee; }
     // operator T*() { return _pointee; }

--- a/retesteth/dataObject/SPointer.h
+++ b/retesteth/dataObject/SPointer.h
@@ -92,6 +92,8 @@ public:
         }
     }
 
+    T* pointee() { return _pointee; }
+
     // Replace one pointer with another
     GCP_SPointer& operator=(GCP_SPointer const& rhs)
     {

--- a/retesteth/dataObject/SPointer.h
+++ b/retesteth/dataObject/SPointer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <exception>
 #include <string>
+
 namespace dataobject
 {
 struct SPointerException : virtual std::exception
@@ -32,12 +33,8 @@ class GCP_SPointerBase
 private:
     int _nRef;
     bool _isEmpty;
-    void AddRef() { _nRef++; }
-    int DelRef()
-    {
-        _nRef--;
-        return _nRef;
-    }
+    void AddRef();
+    int DelRef();
 
 public:
     GCP_SPointerBase() : _nRef(0), _isEmpty(false) {}

--- a/retesteth/session/RPCImpl.cpp
+++ b/retesteth/session/RPCImpl.cpp
@@ -46,7 +46,7 @@ VALUE RPCImpl::eth_getTransactionCount(FH20 const& _address, VALUE const& _block
 
 VALUE RPCImpl::eth_blockNumber()
 {
-    return VALUE(rpcCall("eth_blockNumber", {}));
+    return VALUE(rpcCall("eth_blockNumber", {}).getCContent());
 }
 
 EthGetBlockBy RPCImpl::eth_getBlockByHash(FH32 const& _hash, Request _fullObjects)
@@ -132,20 +132,20 @@ void RPCImpl::test_setChainParams(SetChainParamsArgs const& _config)
     spDataObject data = _config.asDataObject();
     cfg.performFieldReplace(*data, FieldReplaceDir::RetestethToClient);
 
-    auto res =  rpcCall("test_setChainParams", {data->asJson()});
-    ETH_FAIL_REQUIRE_MESSAGE(res == true, "remote test_setChainParams = false");
+    spDataObject res =  rpcCall("test_setChainParams", {data->asJson()});
+    ETH_FAIL_REQUIRE_MESSAGE(*res == true, "remote test_setChainParams = false");
 }
 
 void RPCImpl::test_rewindToBlock(VALUE const& _blockNr)
 {
-    ETH_FAIL_REQUIRE_MESSAGE(
-        rpcCall("test_rewindToBlock", {_blockNr.asDecString()}) == true, "remote test_rewintToBlock = false");
+    spDataObject res = rpcCall("test_rewindToBlock", {_blockNr.asDecString()});
+    ETH_FAIL_REQUIRE_MESSAGE(*res == true, "remote test_rewintToBlock = false");
 }
 
 void RPCImpl::test_modifyTimestamp(VALUE const& _timestamp)
 {
-    ETH_FAIL_REQUIRE_MESSAGE(
-        rpcCall("test_modifyTimestamp", {_timestamp.asDecString()}) == true, "test_modifyTimestamp was not successfull");
+    spDataObject res = rpcCall("test_modifyTimestamp", {_timestamp.asDecString()});
+    ETH_FAIL_REQUIRE_MESSAGE(*res == true, "test_modifyTimestamp was not successfull");
 }
 
 MineBlocksResult RPCImpl::test_mineBlocks(size_t _number)

--- a/retesteth/session/RPCImpl.cpp
+++ b/retesteth/session/RPCImpl.cpp
@@ -132,7 +132,7 @@ void RPCImpl::test_setChainParams(SetChainParamsArgs const& _config)
     spDataObject data = _config.asDataObject();
     cfg.performFieldReplace(*data, FieldReplaceDir::RetestethToClient);
 
-    auto res =  rpcCall("test_setChainParams", {data.asJson()});
+    auto res =  rpcCall("test_setChainParams", {data->asJson()});
     ETH_FAIL_REQUIRE_MESSAGE(res == true, "remote test_setChainParams = false");
 }
 
@@ -150,27 +150,27 @@ void RPCImpl::test_modifyTimestamp(VALUE const& _timestamp)
 
 MineBlocksResult RPCImpl::test_mineBlocks(size_t _number)
 {
-    DataObject const res = rpcCall("test_mineBlocks", {to_string(_number)}, true);
+    spDataObject const res = rpcCall("test_mineBlocks", {to_string(_number)}, true);
 
-    if (res.type() == DataType::Object)
+    if (res->type() == DataType::Object)
     {
-        auto const& result = res.atKey("result");
+        auto const& result = res->atKey("result");
         bool miningres = result.type() == DataType::Bool ? result.asBool() : result.asInt() == 1;
         ETH_ERROR_REQUIRE_MESSAGE(miningres == true, "remote test_mineBlocks = false");
     }
-    else if (res.type() == DataType::Bool)
-        ETH_ERROR_REQUIRE_MESSAGE(res.asBool() == true, "remote test_mineBlocks = false");
+    else if (res->type() == DataType::Bool)
+        ETH_ERROR_REQUIRE_MESSAGE(res->asBool() == true, "remote test_mineBlocks = false");
     else
-        ETH_ERROR_MESSAGE("remote test_mineBlocks = " + res.asJson());
+        ETH_ERROR_MESSAGE("remote test_mineBlocks = " + res->asJson());
 
     return MineBlocksResult(res);
 }
 
 FH32 RPCImpl::test_importRawBlock(BYTES const& _blockRLP)
 {
-    DataObject const res = rpcCall("test_importRawBlock", {quote(_blockRLP.asString())}, true);
-    if (res.type() == DataType::String && res.asString().size() > 2)
-        return FH32(res.asString());
+    spDataObject const res = rpcCall("test_importRawBlock", {quote(_blockRLP.asString())}, true);
+    if (res->type() == DataType::String && res->asString().size() > 2)
+        return FH32(res->asString());
     return FH32(FH32::zero());
 }
 
@@ -237,7 +237,7 @@ spDataObject RPCImpl::rpcCall(
             ETH_FAIL_MESSAGE(m_lastInterfaceError.message());
     }
     m_lastInterfaceError.clear();  // null the error as last RPC call was success.
-    return result.atKey("result");
+    return result.getContent().atKeyPointer("result");
 }
 
 Socket::SocketType RPCImpl::getSocketType() const

--- a/retesteth/session/RPCImpl.h
+++ b/retesteth/session/RPCImpl.h
@@ -9,7 +9,7 @@ public:
     RPCImpl(Socket::SocketType _type, const string& _path) : m_socket(_type, _path) {}
 
 public:
-    DataObject web3_clientVersion() override;
+    spDataObject web3_clientVersion() override;
 
     // ETH Methods
     FH32 eth_sendRawTransaction(BYTES const& _rlp, VALUE const& _secret) override;
@@ -42,7 +42,7 @@ public:
 
     // Internal
     std::string sendRawRequest(std::string const& _request);
-    DataObject rpcCall(std::string const& _methodName,
+    spDataObject rpcCall(std::string const& _methodName,
         std::vector<std::string> const& _args = std::vector<std::string>(),
         bool _canFail = false) override;
     Socket::SocketType getSocketType() const override;

--- a/retesteth/session/SessionInterface.h
+++ b/retesteth/session/SessionInterface.h
@@ -38,7 +38,7 @@ class SessionInterface
 {
 public:
     // DataObject represents json output
-    virtual DataObject web3_clientVersion() = 0;
+    virtual spDataObject web3_clientVersion() = 0;
 
     // ETH Methods
     virtual FH32 eth_sendRawTransaction(BYTES const& _rlp, VALUE const& _secret) = 0;
@@ -70,7 +70,7 @@ public:
     virtual FH32 test_getLogHash(FH32 const& _txHash) = 0;
 
     // Internal
-    virtual DataObject rpcCall(std::string const& _methodName,
+    virtual spDataObject rpcCall(std::string const& _methodName,
         std::vector<std::string> const& _args = std::vector<std::string>(),
         bool _canFail = false) = 0;
     virtual Socket::SocketType getSocketType() const = 0;

--- a/retesteth/session/ToolBackend/ToolChain.cpp
+++ b/retesteth/session/ToolBackend/ToolChain.cpp
@@ -286,7 +286,7 @@ ToolResponse ToolChain::mineBlockOnTool(EthereumBlockState const& _block, SealEn
     // Construct block rpc response
     ToolResponse toolResponse(ConvertJsoncppStringToData(outPathContent));
     spDataObject returnState = ConvertJsoncppStringToData(outAllocPathContent);
-    toolResponse.attachState(restoreFullState(returnState));
+    toolResponse.attachState(restoreFullState(returnState.getContent()));
 
     if (traceCondition)
     {

--- a/retesteth/session/ToolBackend/ToolChain.cpp
+++ b/retesteth/session/ToolBackend/ToolChain.cpp
@@ -227,16 +227,36 @@ ToolResponse ToolChain::mineBlockOnTool(EthereumBlockState const& _block, SealEn
     writeFile(allocPath.string(), allocPathContent);
 
     // txs.json file
-    string const txsfile = _block.transactions().size() ? "txs.rlp" : "txs.json";
+    bool exportRLP = false;
+    string const txsfile = _block.transactions().size() && exportRLP ? "txs.rlp" : "txs.json";
     fs::path txsPath = m_tmpDir / txsfile;
 
-    dev::RLPStream txsout(_block.transactions().size());
-    for (auto const& tr : _block.transactions())
-        txsout.appendRaw(tr->asRLPStream().out());
-
-    string const txsPathContent = _block.transactions().size() ?
-                "\"" + dev::toString(txsout.out()) + "\"" : "[]";
-    writeFile(txsPath.string(), txsPathContent);
+    string txsPathContent;
+    if (exportRLP)
+    {
+        dev::RLPStream txsout(_block.transactions().size());
+        for (auto const& tr : _block.transactions())
+            txsout.appendRaw(tr->asRLPStream().out());
+        string txsPathContent = _block.transactions().size() ?
+                    "\"" + dev::toString(txsout.out()) + "\"" : "[]";
+        writeFile(txsPath.string(), txsPathContent);
+    }
+    else
+    {
+        DataObject txs(DataType::Array);
+        static u256 c_maxGasLimit = u256("0xffffffffffffffff");
+        for (auto const& tr : _block.transactions())
+        {
+            if (tr->gasLimit().asBigInt() <= c_maxGasLimit)  // tool fails on limits here.
+                txs.addArrayObject(tr->asDataObject(ExportOrder::ToolStyle));
+            else
+                ETH_WARNING(
+                    "Retesteth rejecting tx with gasLimit > 64 bits for tool" + TestOutputHelper::get().testInfo().errorDebug());
+        }
+        Options::getCurrentConfig().performFieldReplace(txs, FieldReplaceDir::RetestethToClient);
+        txsPathContent = txs.asJson();
+        writeFile(txsPath.string(), txsPathContent);
+    }
 
     // output file
     fs::path outPath = m_tmpDir / "out.json";

--- a/retesteth/session/ToolBackend/ToolChain.cpp
+++ b/retesteth/session/ToolBackend/ToolChain.cpp
@@ -43,7 +43,7 @@ ToolChain::ToolChain(
     m_blocks.push_back(genesisFixed);
 }
 
-DataObject const ToolChain::mineBlock(EthereumBlockState const& _pendingBlock, Mining _req)
+spDataObject const ToolChain::mineBlock(EthereumBlockState const& _pendingBlock, Mining _req)
 {
     ToolResponse const res = mineBlockOnTool(_pendingBlock, m_engine);
 
@@ -81,8 +81,8 @@ DataObject const ToolChain::mineBlock(EthereumBlockState const& _pendingBlock, M
     // Add only those transactions which tool returned a receipt for
     // Some transactions are expected to fail. That should be detected by tests
     size_t index = 0;
-    DataObject miningResult;
-    miningResult["result"] = true;
+    spDataObject miningResult(new DataObject());
+    (*miningResult)["result"] = true;
 
     for (auto const& tr : _pendingBlock.transactions())
     {
@@ -108,10 +108,10 @@ DataObject const ToolChain::mineBlock(EthereumBlockState const& _pendingBlock, M
                 if (el.index() == index)
                 {
                     rejectedInfoFound = true;
-                    DataObject rejectInfo;
-                    rejectInfo["hash"] = trHash.asString();
-                    rejectInfo["error"] = el.error();
-                    miningResult["rejectedTransactions"].addArrayObject(rejectInfo);
+                    spDataObject rejectInfo(new DataObject());
+                    (*rejectInfo)["hash"] = trHash.asString();
+                    (*rejectInfo)["error"] = el.error();
+                    (*miningResult)["rejectedTransactions"].addArrayObject(rejectInfo);
                     break;
                 }
             }

--- a/retesteth/session/ToolBackend/ToolChain.h
+++ b/retesteth/session/ToolBackend/ToolChain.h
@@ -52,7 +52,7 @@ public:
         RequireValid,
         AllowFailTransactions
     };
-    DataObject const mineBlock(EthereumBlockState const& _pendingBlock, Mining _req = Mining::AllowFailTransactions);
+    spDataObject const mineBlock(EthereumBlockState const& _pendingBlock, Mining _req = Mining::AllowFailTransactions);
     void rewindToBlock(size_t _number);
 
     // Used for chain reorg

--- a/retesteth/session/ToolBackend/ToolChainHelper.cpp
+++ b/retesteth/session/ToolBackend/ToolChainHelper.cpp
@@ -116,17 +116,20 @@ State restoreFullState(DataObject const& _toolState)
     for (auto const& accTool2 : _toolState.getSubObjects())
     {
         DataObject const& accTool = accTool2.getCContent();
-        DataObject acc;
+        DataObject& acc = fullState[accTool.getKey()];
         acc["balance"] = accTool.count("balance") ? accTool.atKey("balance").asString() : "0x00";
         acc["nonce"] = accTool.count("nonce") ? accTool.atKey("nonce").asString() : "0x00";
         acc["code"] = accTool.count("code") ? accTool.atKey("code").asString() : "0x";
-        acc["storage"] = accTool.count("storage") ? accTool.atKey("storage") : DataObject(DataType::Object);
+        if (accTool.count("storage"))
+            acc["storage"].copyFrom(accTool.atKey("storage"));
+        else
+            acc["storage"].copyFrom(spDataObject(new DataObject(DataType::Object)));
         for (auto& storageRecord : acc.atKeyUnsafe("storage").getSubObjectsUnsafe())
         {
             storageRecord.getContent().performModifier(mod_removeLeadingZerosFromHexValuesEVEN);
             storageRecord.getContent().performModifier(mod_removeLeadingZerosFromHexKeysEVEN);
         }
-        fullState[accTool.getKey()] = acc;
+        //fullState[accTool.getKey()] = acc;
     }
     return State(fullState);
 }

--- a/retesteth/session/ToolBackend/ToolChainHelper.cpp
+++ b/retesteth/session/ToolBackend/ToolChainHelper.cpp
@@ -113,8 +113,9 @@ VALUE calculateGasLimit(VALUE const& _parentGasLimit, VALUE const& _parentGasUse
 State restoreFullState(DataObject const& _toolState)
 {
     DataObject fullState;
-    for (auto const& accTool : _toolState.getSubObjects())
+    for (auto const& accTool2 : _toolState.getSubObjects())
     {
+        DataObject const& accTool = accTool2.getCContent();
         DataObject acc;
         acc["balance"] = accTool.count("balance") ? accTool.atKey("balance").asString() : "0x00";
         acc["nonce"] = accTool.count("nonce") ? accTool.atKey("nonce").asString() : "0x00";
@@ -122,8 +123,8 @@ State restoreFullState(DataObject const& _toolState)
         acc["storage"] = accTool.count("storage") ? accTool.atKey("storage") : DataObject(DataType::Object);
         for (auto& storageRecord : acc.atKeyUnsafe("storage").getSubObjectsUnsafe())
         {
-            storageRecord.performModifier(mod_removeLeadingZerosFromHexValuesEVEN);
-            storageRecord.performModifier(mod_removeLeadingZerosFromHexKeysEVEN);
+            storageRecord.getContent().performModifier(mod_removeLeadingZerosFromHexValuesEVEN);
+            storageRecord.getContent().performModifier(mod_removeLeadingZerosFromHexKeysEVEN);
         }
         fullState[accTool.getKey()] = acc;
     }

--- a/retesteth/session/ToolBackend/ToolChainHelper.cpp
+++ b/retesteth/session/ToolBackend/ToolChainHelper.cpp
@@ -110,20 +110,20 @@ VALUE calculateGasLimit(VALUE const& _parentGasLimit, VALUE const& _parentGasUse
 
 // Because tool report incomplete state. restore missing fields with zeros
 // Also remove leading zeros in storage
-State restoreFullState(DataObject const& _toolState)
+State restoreFullState(DataObject& _toolState)
 {
     DataObject fullState;
-    for (auto const& accTool2 : _toolState.getSubObjects())
+    for (auto& accTool2 : _toolState.getSubObjectsUnsafe())
     {
-        DataObject const& accTool = accTool2.getCContent();
+        DataObject& accTool = accTool2.getContent();
         DataObject& acc = fullState[accTool.getKey()];
         acc["balance"] = accTool.count("balance") ? accTool.atKey("balance").asString() : "0x00";
         acc["nonce"] = accTool.count("nonce") ? accTool.atKey("nonce").asString() : "0x00";
         acc["code"] = accTool.count("code") ? accTool.atKey("code").asString() : "0x";
         if (accTool.count("storage"))
-            acc["storage"].copyFrom(accTool.atKey("storage"));
+            acc.atKeyPointer("storage") = accTool.atKeyPointerUnsafe("storage");
         else
-            acc["storage"].copyFrom(spDataObject(new DataObject(DataType::Object)));
+            acc.atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
         for (auto& storageRecord : acc.atKeyUnsafe("storage").getSubObjectsUnsafe())
         {
             storageRecord.getContent().performModifier(mod_removeLeadingZerosFromHexValuesEVEN);

--- a/retesteth/session/ToolBackend/ToolChainHelper.h
+++ b/retesteth/session/ToolBackend/ToolChainHelper.h
@@ -26,6 +26,6 @@ VALUE calculateGasLimit(VALUE const& _parentGasLimit, VALUE const& _parentGasUse
 VALUE calculateEthashDifficulty(
     ChainOperationParams const& _chainParams, spBlockHeader const& _bi, spBlockHeader const& _parent);
 VALUE calculateEIP1559BaseFee(ChainOperationParams const& _chainParams, spBlockHeader const& _bi, spBlockHeader const& _parent);
-State restoreFullState(DataObject const& _toolState);
+State restoreFullState(DataObject& _toolState);
 
 }  // namespace toolimpl

--- a/retesteth/session/ToolBackend/ToolChainManager.cpp
+++ b/retesteth/session/ToolBackend/ToolChainManager.cpp
@@ -19,11 +19,11 @@ ToolChainManager::ToolChainManager(SetChainParamsArgs const& _config, fs::path c
     reorganizePendingBlock();
 }
 
-DataObject const ToolChainManager::mineBlocks(size_t _number, ToolChain::Mining _req)
+spDataObject const ToolChainManager::mineBlocks(size_t _number, ToolChain::Mining _req)
 {
     if (_number > 1)
         throw test::UpwardsException("ToolChainManager::mineBlocks number arg invalid: " + fto_string(_number));
-    DataObject const res = currentChainUnsafe().mineBlock(m_pendingBlock, _req);
+    spDataObject const res = currentChainUnsafe().mineBlock(m_pendingBlock, _req);
     reorganizePendingBlock();
     return res;
 }

--- a/retesteth/session/ToolBackend/ToolChainManager.cpp
+++ b/retesteth/session/ToolBackend/ToolChainManager.cpp
@@ -42,14 +42,14 @@ void ToolChainManager::reorganizePendingBlock()
     if (currentChain().fork() == "BerlinToLondonAt5" && bl.header()->number() == 4)
     {
         // Switch default mining to 1559 blocks
-        DataObject parentData = bl.header()->asDataObject();
+        spDataObject parentData = bl.header()->asDataObject();
 
         VALUE newGasLimit = bl.header()->gasLimit() * ELASTICITY_MULTIPLIER;
-        parentData.atKeyUnsafe("gasLimit").setString(newGasLimit.asString());
+        (*parentData).atKeyUnsafe("gasLimit").setString(newGasLimit.asString());
 
         // https://eips.ethereum.org/EIPS/eip-1559
         // INITIAL_BASE_FEE = 1000000000
-        parentData["baseFeePerGas"] = VALUE(INITIAL_BASE_FEE).asString();
+        (*parentData)["baseFeePerGas"] = VALUE(INITIAL_BASE_FEE).asString();
 
         spBlockHeader newPending(new BlockHeader1559(parentData));
         m_pendingBlock = spEthereumBlockState(new EthereumBlockState(newPending, bl.state(), bl.logHash()));
@@ -110,7 +110,7 @@ FH32 ToolChainManager::importRawBlock(BYTES const& _rlp)
         toolimpl::verifyBlockRLP(rlp);
 
         spBlockHeader header = readBlockHeader(rlp[0]);
-        ETH_TEST_MESSAGE(header->asDataObject().asJson());
+        ETH_TEST_MESSAGE(header->asDataObject()->asJson());
         for (auto const& chain : m_chains)
             for (auto const& bl : chain.second->blocks())
                 if (bl.header()->hash() == header->hash())
@@ -124,7 +124,7 @@ FH32 ToolChainManager::importRawBlock(BYTES const& _rlp)
         for (auto const& trRLP : rlp[1].toList())
         {
             spTransaction spTr = readTransaction(trRLP);
-            ETH_TEST_MESSAGE(spTr->asDataObject().asJson());
+            ETH_TEST_MESSAGE(spTr->asDataObject()->asJson());
             addPendingTransaction(spTr);
         }
 

--- a/retesteth/session/ToolBackend/ToolChainManager.h
+++ b/retesteth/session/ToolBackend/ToolChainManager.h
@@ -22,7 +22,7 @@ public:
         assert(m_chains.count(m_currentChain));
         return m_chains.at(m_currentChain);
     }
-    DataObject const mineBlocks(size_t _number, ToolChain::Mining _req = ToolChain::Mining::AllowFailTransactions);
+    spDataObject const mineBlocks(size_t _number, ToolChain::Mining _req = ToolChain::Mining::AllowFailTransactions);
     FH32 importRawBlock(BYTES const& _rlp);
 
     EthereumBlockState const& lastBlock() const { return currentChain().lastBlock(); }

--- a/retesteth/session/ToolBackend/ToolImplHelper.cpp
+++ b/retesteth/session/ToolBackend/ToolImplHelper.cpp
@@ -11,7 +11,7 @@ spDataObject constructAccountRange(EthereumBlockState const& _block, FH32 const&
     size_t iAcc = hexOrDecStringToInt(_addrHash.asString());
     spDataObject constructResponse (new DataObject());
     spDataObject emptyList(new DataObject(DataType::Object));
-    (*constructResponse)["addressMap"].copyFrom(emptyList);
+    (*constructResponse).atKeyPointer("addressMap") = emptyList;
     for (auto const& acc : _block.state().accounts())
     {
         if (k++ + 1 < iAcc)  // The first key is 1 must be included
@@ -34,7 +34,7 @@ spDataObject constructEthGetBlockBy(EthereumBlockState const& _block)
     spDataObject constructResponse = _block.header()->asDataObject();
 
     spDataObject transactionArray(new DataObject(DataType::Array));
-    (*constructResponse)["transactions"].copyFrom(transactionArray);
+    (*constructResponse).atKeyPointer("transactions") = transactionArray;
     for (auto const& tr : _block.transactions())
     {
         spDataObject fullTransaction = tr->asDataObject();
@@ -46,8 +46,8 @@ spDataObject constructEthGetBlockBy(EthereumBlockState const& _block)
         (*constructResponse)["transactions"].addArrayObject(fullTransaction);
     }
 
-    spDataObject arr(DataType::Array);
-    (*constructResponse)["uncles"].copyFrom(arr);
+    spDataObject arr(new DataObject(DataType::Array));
+    (*constructResponse).atKeyPointer("uncles") = arr;
     for (auto const& un : _block.uncles())
     {
         spDataObject unHash(new DataObject(un->hash().asString()));
@@ -71,8 +71,8 @@ spDataObject constructStorageRangeAt(
     if (_block.state().hasAccount(_address))
     {
         (*constructResponse)["complete"].setBool(true);
-        spDataObject obj(new DataObject());
-        (*constructResponse)["storage"].copyFrom(obj);
+        spDataObject obj(new DataObject(DataType::Object));
+        (*constructResponse).atKeyPointer("storage") = obj;
         (*constructResponse)["nextKey"] = FH32::zero().asString();
         if (_block.state().getAccount(_address).hasStorage())
         {
@@ -82,7 +82,7 @@ spDataObject constructStorageRangeAt(
             {
                 if (iStore++ + 1 < iBegin)
                     continue;
-                DataObject& record = (*constructResponse)[fto_string(iStore)];
+                DataObject& record = (*obj)[fto_string(iStore)];
                 record["key"] = std::get<0>(el.second)->asString();
                 record["value"] = std::get<1>(el.second)->asString();
                 record.performModifier(mod_removeLeadingZerosFromHexValuesEVEN);

--- a/retesteth/session/ToolBackend/ToolImplHelper.cpp
+++ b/retesteth/session/ToolBackend/ToolImplHelper.cpp
@@ -5,68 +5,75 @@ using namespace test;
 
 namespace toolimpl
 {
-DataObject constructAccountRange(EthereumBlockState const& _block, FH32 const& _addrHash, size_t _maxResult)
+spDataObject constructAccountRange(EthereumBlockState const& _block, FH32 const& _addrHash, size_t _maxResult)
 {
     size_t k = 0;
     size_t iAcc = hexOrDecStringToInt(_addrHash.asString());
-    DataObject constructResponse;
-    constructResponse["addressMap"] = DataObject(DataType::Object);
+    spDataObject constructResponse (new DataObject());
+    spDataObject emptyList(new DataObject(DataType::Object));
+    (*constructResponse)["addressMap"].copyFrom(emptyList);
     for (auto const& acc : _block.state().accounts())
     {
         if (k++ + 1 < iAcc)  // The first key is 1 must be included
             continue;
 
-        constructResponse["addressMap"].addSubObject(fto_string(iAcc++), DataObject(acc.first.asString()));
-        if (constructResponse.atKey("addressMap").getSubObjects().size() == _maxResult)
+        spDataObject address(new DataObject(acc.first.asString()));
+        (*constructResponse)["addressMap"].addSubObject(fto_string(iAcc++), address);
+        if (constructResponse->atKey("addressMap").getSubObjects().size() == _maxResult)
             break;
     }
-    if (constructResponse.atKey("addressMap").getSubObjects().size() == 0)
-        constructResponse["nextKey"] = test::stoCompactHexPrefixed(0, 32);
+    if (constructResponse->atKey("addressMap").getSubObjects().size() == 0)
+        (*constructResponse)["nextKey"] = test::stoCompactHexPrefixed(0, 32);
     else
-        constructResponse["nextKey"] = test::stoCompactHexPrefixed(k + 1, 32);  // because we rely on empty structure +1
+        (*constructResponse)["nextKey"] = test::stoCompactHexPrefixed(k + 1, 32);  // because we rely on empty structure +1
     return constructResponse;
 }
 
-DataObject constructEthGetBlockBy(EthereumBlockState const& _block)
+spDataObject constructEthGetBlockBy(EthereumBlockState const& _block)
 {
-    DataObject constructResponse = _block.header()->asDataObject();
+    spDataObject constructResponse = _block.header()->asDataObject();
 
-    constructResponse["transactions"] = DataObject(DataType::Array);
+    spDataObject transactionArray(new DataObject(DataType::Array));
+    (*constructResponse)["transactions"].copyFrom(transactionArray);
     for (auto const& tr : _block.transactions())
     {
-        DataObject fullTransaction = tr->asDataObject();
-        fullTransaction["blockHash"] =
-            _block.header()->hash().asString();  // We don't know the hash its in tool response
-        fullTransaction["blockNumber"] = _block.header()->number().asString();
-        fullTransaction["from"] = FH20::zero().asString();  // Can be recovered from vrs
-        fullTransaction["transactionIndex"] = "0x00";       // Its in tool response
-        fullTransaction["hash"] = tr->hash().asString();
-        constructResponse["transactions"].addArrayObject(fullTransaction);
+        spDataObject fullTransaction = tr->asDataObject();
+        (*fullTransaction)["blockHash"] = _block.header()->hash().asString();  // We don't know the hash its in tool response
+        (*fullTransaction)["blockNumber"] = _block.header()->number().asString();
+        (*fullTransaction)["from"] = FH20::zero().asString();  // Can be recovered from vrs
+        (*fullTransaction)["transactionIndex"] = "0x00";       // Its in tool response
+        (*fullTransaction)["hash"] = tr->hash().asString();
+        (*constructResponse)["transactions"].addArrayObject(fullTransaction);
     }
 
-    constructResponse["uncles"] = DataObject(DataType::Array);
+    spDataObject arr(DataType::Array);
+    (*constructResponse)["uncles"].copyFrom(arr);
     for (auto const& un : _block.uncles())
-        constructResponse["uncles"].addArrayObject(un->hash().asString());
+    {
+        spDataObject unHash(new DataObject(un->hash().asString()));
+        (*constructResponse)["uncles"].addArrayObject(unHash);
+    }
 
-    constructResponse["size"] = "0x00";
-    constructResponse["totalDifficulty"] = "0x00";
-    constructResponse.renameKey("bloom", "logsBloom");
-    constructResponse.renameKey("coinbase", "miner");
-    constructResponse.renameKey("receiptTrie", "receiptsRoot");
-    constructResponse.renameKey("transactionsTrie", "transactionsRoot");
-    constructResponse.renameKey("uncleHash", "sha3Uncles");
+    (*constructResponse)["size"] = "0x00";
+    (*constructResponse)["totalDifficulty"] = "0x00";
+    (*constructResponse).renameKey("bloom", "logsBloom");
+    (*constructResponse).renameKey("coinbase", "miner");
+    (*constructResponse).renameKey("receiptTrie", "receiptsRoot");
+    (*constructResponse).renameKey("transactionsTrie", "transactionsRoot");
+    (*constructResponse).renameKey("uncleHash", "sha3Uncles");
     return constructResponse;
 }
 
-DataObject constructStorageRangeAt(
+spDataObject constructStorageRangeAt(
     EthereumBlockState const& _block, FH20 const& _address, FH32 const& _begin, size_t _maxResult)
 {
-    DataObject constructResponse;
+    spDataObject constructResponse (new DataObject());
     if (_block.state().hasAccount(_address))
     {
-        constructResponse["complete"].setBool(true);
-        constructResponse["storage"] = DataObject(DataType::Object);
-        constructResponse["nextKey"] = FH32::zero().asString();
+        (*constructResponse)["complete"].setBool(true);
+        spDataObject obj(new DataObject());
+        (*constructResponse)["storage"].copyFrom(obj);
+        (*constructResponse)["nextKey"] = FH32::zero().asString();
         if (_block.state().getAccount(_address).hasStorage())
         {
             size_t iStore = 0;
@@ -75,23 +82,25 @@ DataObject constructStorageRangeAt(
             {
                 if (iStore++ + 1 < iBegin)
                     continue;
-                DataObject record;
+                DataObject& record = (*constructResponse)[fto_string(iStore)];
                 record["key"] = std::get<0>(el.second)->asString();
                 record["value"] = std::get<1>(el.second)->asString();
                 record.performModifier(mod_removeLeadingZerosFromHexValuesEVEN);
-                constructResponse["storage"][fto_string(iStore)] = record;
-                if (constructResponse.atKey("storage").getSubObjects().size() == _maxResult)
+
+                if (constructResponse->atKey("storage").getSubObjects().size() == _maxResult)
                 {
-                    constructResponse["complete"].setBool(false);
-                    constructResponse["nextKey"] = dev::toCompactHexPrefixed(iStore + 1, 32);
+                    (*constructResponse)["complete"].setBool(false);
+                    (*constructResponse)["nextKey"] = dev::toCompactHexPrefixed(iStore + 1, 32);
                     break;
                 }
             }
         }
         else
-            constructResponse["storage"] = DataObject();
+        {
+            (*constructResponse)["storage"];
+        }
     }
-    ETH_LOG(constructResponse.asJson(), 7);
+    ETH_LOG(constructResponse->asJson(), 7);
     return constructResponse;
 }
 

--- a/retesteth/session/ToolBackend/ToolImplHelper.h
+++ b/retesteth/session/ToolBackend/ToolImplHelper.h
@@ -6,14 +6,14 @@ using namespace dataobject;
 namespace toolimpl
 {
 // Construct accountRange RPC style
-DataObject constructAccountRange(EthereumBlockState const& _block, FH32 const& _addrHash, size_t _maxResult);
+spDataObject constructAccountRange(EthereumBlockState const& _block, FH32 const& _addrHash, size_t _maxResult);
 
 // Construct storageRange RPC style
-DataObject constructStorageRangeAt(
+spDataObject constructStorageRangeAt(
     EthereumBlockState const& _block, FH20 const& _address, FH32 const& _begin, size_t _maxResult);
 
 // Construct RPC style response
-DataObject constructEthGetBlockBy(EthereumBlockState const& _block);
+spDataObject constructEthGetBlockBy(EthereumBlockState const& _block);
 
 // RLP Validators
 void verifyBlockRLP(dev::RLP const& _rlp);

--- a/retesteth/session/ToolBackend/Verification.cpp
+++ b/retesteth/session/ToolBackend/Verification.cpp
@@ -91,20 +91,20 @@ void verify1559Parent(spBlockHeader const& _header, spBlockHeader const& _parent
         if (_parent->type() != BlockType::BlockHeaderLegacy)
             ETH_FAIL_MESSAGE("verify1559Parent first 1559 block must be on top of legacy block!");
 
-        DataObject parentData = _parent->asDataObject();
+        spDataObject parentData = _parent->asDataObject();
 
         // fake legacy block gasLimit for delta validation
         // https://eips.ethereum.org/EIPS/eip-1559
         // if INITIAL_FORK_BLOCK_NUMBER == block.number:
         //            parent_gas_target = self.parent(block).gas_limit
         //            parent_gas_limit = self.parent(block).gas_limit * ELASTICITY_MULTIPLIER
-        parentData["gasLimit"] = (_parent->gasLimit() * ELASTICITY_MULTIPLIER).asString();
+        (*parentData)["gasLimit"] = (_parent->gasLimit() * ELASTICITY_MULTIPLIER).asString();
 
         // https://eips.ethereum.org/EIPS/eip-1559
         // INITIAL_BASE_FEE = 1000000000
         // fake legacy block baseFee for delta validation
         VALUE genesisBaseFee = INITIAL_BASE_FEE * 8 / 7;
-        parentData["baseFeePerGas"] = genesisBaseFee.asString();
+        (*parentData)["baseFeePerGas"] = genesisBaseFee.asString();
 
         spBlockHeader fixedParent = spBlockHeader(new BlockHeader1559(parentData));
         verify1559Parent_private(_header, fixedParent, _chain);

--- a/retesteth/session/ToolImpl.cpp
+++ b/retesteth/session/ToolImpl.cpp
@@ -43,17 +43,17 @@ enum class CallType
     }                                                                                                      \
 
 
-DataObject ToolImpl::web3_clientVersion()
+spDataObject ToolImpl::web3_clientVersion()
 {
     rpcCall("", {});
     ETH_TEST_MESSAGE("\nRequest: web3_clientVersion");
     string const cmd = m_toolPath.string() + " -v";
     TRYCATCHCALL(
-                DataObject res(test::executeCmd(cmd));
-                ETH_TEST_MESSAGE("Response: web3_clientVersion " + res.asString());
+                spDataObject res(new DataObject(test::executeCmd(cmd)));
+                ETH_TEST_MESSAGE("Response: web3_clientVersion " + res->asString());
                 return res;
                 , "web3_clientVersion", CallType::FAILEVERYTHING)
-    return DataObject();
+    return spDataObject();
 }
 
 // ETH Methods
@@ -64,7 +64,7 @@ FH32 ToolImpl::eth_sendRawTransaction(BYTES const& _rlp, VALUE const& _secret)
     TRYCATCHCALL(
         spTransaction spTr = readTransaction(_rlp);
         spTr.getContent().setSecret(_secret);
-        ETH_TEST_MESSAGE(spTr->asDataObject().asJson());
+        ETH_TEST_MESSAGE(spTr->asDataObject()->asJson());
         m_toolChainManager.getContent().addPendingTransaction(spTr);
         FH32 trHash = spTr.getContent().hash();
         ETH_TEST_MESSAGE("Response: " + trHash.asString());
@@ -105,8 +105,8 @@ EthGetBlockBy ToolImpl::eth_getBlockByHash(FH32 const& _hash, Request _fullObjec
     (void)_fullObjects;
     ETH_TEST_MESSAGE("\nRequest: eth_getBlockByHash `" + _hash.asString());
     TRYCATCHCALL(
-        DataObject res = constructEthGetBlockBy(blockchain().blockByHash(_hash));
-        ETH_LOG("Response: eth_getBlockByHash `" + res.asJson(), 7);
+        spDataObject res = constructEthGetBlockBy(blockchain().blockByHash(_hash));
+        ETH_LOG("Response: eth_getBlockByHash `" + res->asJson(), 7);
         return EthGetBlockBy(res);
         , "eth_getBlockByHash", CallType::FAILEVERYTHING)
     return EthGetBlockBy(DataObject());
@@ -118,8 +118,8 @@ EthGetBlockBy ToolImpl::eth_getBlockByNumber(VALUE const& _blockNumber, Request 
     (void)_fullObjects;
     ETH_TEST_MESSAGE("\nRequest: eth_getBlockByNumber `" + _blockNumber.asDecString());
     TRYCATCHCALL(
-        DataObject res = constructEthGetBlockBy(blockchain().blockByNumber(_blockNumber));
-        ETH_LOG("Response: eth_getBlockByNumber `" + res.asJson(), 7);
+        spDataObject res = constructEthGetBlockBy(blockchain().blockByNumber(_blockNumber));
+        ETH_LOG("Response: eth_getBlockByNumber `" + res->asJson(), 7);
         return EthGetBlockBy(res);
         , "eth_getBlockByNumber", CallType::FAILEVERYTHING)
     return EthGetBlockBy(DataObject());
@@ -158,9 +158,9 @@ DebugAccountRange ToolImpl::debug_accountRange(
     (void) _txIndex;
 
     TRYCATCHCALL(
-        DataObject constructResponse =
+        spDataObject constructResponse =
             constructAccountRange(blockchain().blockByNumber(_blockNumber), _addressHash, _maxResults);
-        ETH_TEST_MESSAGE("Response: debug_accountRange " + constructResponse.asJson());
+        ETH_TEST_MESSAGE("Response: debug_accountRange " + constructResponse->asJson());
         return DebugAccountRange(constructResponse);
         , "debug_accountRange", CallType::FAILEVERYTHING)
     return DebugAccountRange(DataObject());
@@ -174,8 +174,8 @@ DebugAccountRange ToolImpl::debug_accountRange(
     (void) _txIndex;
 
     TRYCATCHCALL(
-        DataObject constructResponse = constructAccountRange(blockchain().blockByHash(_blockHash), _addressHash, _maxResults);
-        ETH_TEST_MESSAGE("Response: debug_accountRange " + constructResponse.asJson());
+        spDataObject constructResponse = constructAccountRange(blockchain().blockByHash(_blockHash), _addressHash, _maxResults);
+        ETH_TEST_MESSAGE("Response: debug_accountRange " + constructResponse->asJson());
         return DebugAccountRange(constructResponse);
         , "debug_accountRange", CallType::FAILEVERYTHING)
     return DebugAccountRange(DataObject());
@@ -190,9 +190,9 @@ DebugStorageRangeAt ToolImpl::debug_storageRangeAt(
     (void) _txIndex;
 
     TRYCATCHCALL(
-        DataObject constructResponse =
+        spDataObject constructResponse =
             constructStorageRangeAt(blockchain().blockByNumber(_blockNumber), _address, _begin, _maxResults);
-        ETH_TEST_MESSAGE("Response: debug_storageRangeAt " + constructResponse.asJson());
+        ETH_TEST_MESSAGE("Response: debug_storageRangeAt " + constructResponse->asJson());
         return DebugStorageRangeAt(constructResponse);
         , "debug_storageRangeAt", CallType::FAILEVERYTHING)
     return DebugStorageRangeAt(DataObject());
@@ -207,9 +207,9 @@ DebugStorageRangeAt ToolImpl::debug_storageRangeAt(
     (void) _txIndex;
 
     TRYCATCHCALL(
-        DataObject constructResponse =
+        spDataObject constructResponse =
             constructStorageRangeAt(blockchain().blockByHash(_blockHash), _address, _begin, _maxResults);
-        ETH_TEST_MESSAGE("Response: debug_storageRangeAt " + constructResponse.asJson());
+        ETH_TEST_MESSAGE("Response: debug_storageRangeAt " + constructResponse->asJson());
         return DebugStorageRangeAt(constructResponse);
         , "debug_storageRangeAt", CallType::FAILEVERYTHING)
     return DebugStorageRangeAt(DataObject());
@@ -229,7 +229,7 @@ DebugVMTrace ToolImpl::debug_traceTransaction(FH32 const& _trHash)
 void ToolImpl::test_setChainParams(SetChainParamsArgs const& _config)
 {
     rpcCall("", {});
-    ETH_TEST_MESSAGE("\nRequest: test_setChainParams \n" + _config.asDataObject().asJson());
+    ETH_TEST_MESSAGE("\nRequest: test_setChainParams \n" + _config.asDataObject()->asJson());
 
     // Ask tool to calculate genesis header stateRoot for genesisHeader
     TRYCATCHCALL(
@@ -264,9 +264,9 @@ MineBlocksResult ToolImpl::test_mineBlocks(size_t _number)
     rpcCall("", {});
     ETH_TEST_MESSAGE("\nRequest: test_mineBlocks");
     TRYCATCHCALL(
-        DataObject const res = blockchain().mineBlocks(_number);
+        spDataObject const res = blockchain().mineBlocks(_number);
         ETH_TEST_MESSAGE("Response test_mineBlocks {" + blockchain().lastBlock().header()->number().asDecString() + "}");
-        ETH_TEST_MESSAGE(res.asJson());
+        ETH_TEST_MESSAGE(res->asJson());
         return MineBlocksResult(res);
             , "test_mineBlocks", CallType::FAILEVERYTHING)
     return MineBlocksResult(DataObject());
@@ -300,7 +300,7 @@ FH32 ToolImpl::test_getLogHash(FH32 const& _txHash)
 }
 
 // Internal
-DataObject ToolImpl::rpcCall(
+spDataObject ToolImpl::rpcCall(
     std::string const& _methodName, std::vector<std::string> const& _args, bool _canFail)
 {
     m_lastInterfaceError.clear();
@@ -309,7 +309,7 @@ DataObject ToolImpl::rpcCall(
     (void)_methodName;
     (void)_args;
     (void)_canFail;
-    return DataObject();
+    return spDataObject(0);
 }
 
 Socket::SocketType ToolImpl::getSocketType() const

--- a/retesteth/session/ToolImpl.h
+++ b/retesteth/session/ToolImpl.h
@@ -14,7 +14,7 @@ public:
     {}
 
 public:
-    DataObject web3_clientVersion() override;
+    spDataObject web3_clientVersion() override;
 
     // ETH Methods
     FH32 eth_sendRawTransaction(BYTES const& _rlp, VALUE const& _secret) override;
@@ -47,7 +47,7 @@ public:
 
     // Internal
     std::string sendRawRequest(std::string const& _request);
-    DataObject rpcCall(std::string const& _methodName,
+    spDataObject rpcCall(std::string const& _methodName,
         std::vector<std::string> const& _args = std::vector<std::string>(),
         bool _canFail = false) override;
     Socket::SocketType getSocketType() const override;

--- a/retesteth/testStructures/Common.cpp
+++ b/retesteth/testStructures/Common.cpp
@@ -244,12 +244,13 @@ void requireJsonFields(DataObject const& _o, std::string const& _config, std::ma
 
 // Compile LLL in code
 // Convert dec fields to hex, add 0x prefix to accounts and storage keys
-DataObject convertDecStateToHex(DataObject const& _data, solContracts const& _preSolidity)
+spDataObject convertDecStateToHex(DataObject const& _data, solContracts const& _preSolidity)
 {
     // -- Compile LLL in pre state into byte code if not already
     // -- Convert State::Storage keys/values into hex
-    DataObject tmpD = _data;
-    for (auto& acc2 : tmpD.getSubObjectsUnsafe())
+    spDataObject tmpD;
+    tmpD.getContent().copyFrom(_data);
+    for (auto& acc2 : (*tmpD).getSubObjectsUnsafe())
     {
         DataObject& acc = acc2.getContent();
         if (acc.getKey()[1] != 'x')
@@ -267,19 +268,20 @@ DataObject convertDecStateToHex(DataObject const& _data, solContracts const& _pr
 }
 
 // Convert dec fields to hex, add 0x prefix to accounts and storage keys
-DataObject convertDecBlockheaderIncompleteToHex(DataObject const& _data)
+spDataObject convertDecBlockheaderIncompleteToHex(DataObject const& _data)
 {
     // Convert to HEX
-    DataObject tmpD = _data;
-    tmpD.removeKey("RelTimestamp");     // BlockchainTestFiller fields
-    tmpD.removeKey("chainname");        // BlockchainTestFiller fields
+    spDataObject tmpD;
+    (*tmpD).copyFrom(_data);
+    (*tmpD).removeKey("RelTimestamp");     // BlockchainTestFiller fields
+    (*tmpD).removeKey("chainname");        // BlockchainTestFiller fields
 
     std::vector<string> hashKeys = {"parentHash", "coinbase", "bloom"};
     for (auto const& key : hashKeys)
         if (_data.count(key))
         {
             if (_data.atKey(key).asString().size() > 1 && _data.atKey(key).asString()[1] != 'x')
-                tmpD[key] = "0x" + _data.atKey(key).asString();
+                (*tmpD)[key] = "0x" + _data.atKey(key).asString();
         }
 
     std::vector<string> valueKeys = {
@@ -293,7 +295,7 @@ DataObject convertDecBlockheaderIncompleteToHex(DataObject const& _data)
     };
     for (auto const& key : valueKeys)
         if (_data.count(key))
-            tmpD[key].performModifier(mod_valueToCompactEvenHexPrefixed);
+            (*tmpD)[key].performModifier(mod_valueToCompactEvenHexPrefixed);
     return tmpD;
 }
 

--- a/retesteth/testStructures/Common.cpp
+++ b/retesteth/testStructures/Common.cpp
@@ -5,6 +5,7 @@
 #include <retesteth/Options.h>
 #include <retesteth/configs/ClientConfig.h>
 #include <mutex>
+#include <algorithm>
 
 using namespace test;
 using namespace dev;
@@ -77,7 +78,11 @@ void mod_valueToCompactEvenHexPrefixed(DataObject& _obj)
         try
         {
             if (!(_obj.asString()[0] == '0' && _obj.asString()[1] == 'x'))
-                _obj.setString(toCompactHexPrefixed(_obj.asString(), 1));
+            {
+                string src = _obj.asString();
+                src.erase(std::remove(src.begin(), src.end(), '_'), src.end());
+                _obj.setString(toCompactHexPrefixed(src, 1));
+            }
         }
         catch (std::exception const& _ex)
         {

--- a/retesteth/testStructures/Common.cpp
+++ b/retesteth/testStructures/Common.cpp
@@ -248,8 +248,8 @@ spDataObject convertDecStateToHex(DataObject const& _data, solContracts const& _
 {
     // -- Compile LLL in pre state into byte code if not already
     // -- Convert State::Storage keys/values into hex
-    spDataObject tmpD;
-    tmpD.getContent().copyFrom(_data);
+    spDataObject tmpD(new DataObject());
+    tmpD.getContent().copyFrom(_data); // TODO copy HERE time consuming!!!
     for (auto& acc2 : (*tmpD).getSubObjectsUnsafe())
     {
         DataObject& acc = acc2.getContent();
@@ -271,8 +271,8 @@ spDataObject convertDecStateToHex(DataObject const& _data, solContracts const& _
 spDataObject convertDecBlockheaderIncompleteToHex(DataObject const& _data)
 {
     // Convert to HEX
-    spDataObject tmpD;
-    (*tmpD).copyFrom(_data);
+    spDataObject tmpD(new DataObject());
+    (*tmpD).copyFrom(_data);               // TODO copy time consuming!!!
     (*tmpD).removeKey("RelTimestamp");     // BlockchainTestFiller fields
     (*tmpD).removeKey("chainname");        // BlockchainTestFiller fields
 

--- a/retesteth/testStructures/Common.cpp
+++ b/retesteth/testStructures/Common.cpp
@@ -63,8 +63,8 @@ void mod_removeComments(DataObject& _obj)
     std::list<string> keysToRemove;
     for (auto& el : _obj.getSubObjectsUnsafe())
     {
-        if (el.getKey()[0] == '/' && el.getKey()[1] == '/')
-            keysToRemove.push_back(el.getKey());
+        if (el->getKey()[0] == '/' && el->getKey()[1] == '/')
+            keysToRemove.push_back(el->getKey());
     }
     for (auto const& key : keysToRemove)
         _obj.removeKey(key);
@@ -154,11 +154,11 @@ void requireJsonFields(
     // check for unexpected fiedls
     for (auto const& field : _o.getSubObjects())
     {
-        string message = "'" + field.getKey() + "' should not be declared in '" + _section + "' section!";
+        string message = "'" + field->getKey() + "' should not be declared in '" + _section + "' section!";
         if (_fail)
-            ETH_FAIL_REQUIRE_MESSAGE(_validationMap.count(field.getKey()), message);
+            ETH_FAIL_REQUIRE_MESSAGE(_validationMap.count(field->getKey()), message);
         else
-            ETH_ERROR_REQUIRE_MESSAGE(_validationMap.count(field.getKey()), message);
+            ETH_ERROR_REQUIRE_MESSAGE(_validationMap.count(field->getKey()), message);
     }
 
     // check field types with validation map
@@ -197,9 +197,9 @@ void requireJsonFields(DataObject const& _o, std::string const& _config, std::ma
     // check for unexpected fiedls
     for (auto const& field : _o.getSubObjects())
     {
-        if (!_validationMap.count(field.getKey()))
+        if (!_validationMap.count(field->getKey()))
         {
-            std::string const comment = "Unexpected field '" + field.getKey() + "' in config: " + _config;
+            std::string const comment = "Unexpected field '" + field->getKey() + "' in config: " + _config;
             ETH_ERROR_MESSAGE(comment + "\n" + _o.asJson());
         }
     }
@@ -249,8 +249,9 @@ DataObject convertDecStateToHex(DataObject const& _data, solContracts const& _pr
     // -- Compile LLL in pre state into byte code if not already
     // -- Convert State::Storage keys/values into hex
     DataObject tmpD = _data;
-    for (auto& acc : tmpD.getSubObjectsUnsafe())
+    for (auto& acc2 : tmpD.getSubObjectsUnsafe())
     {
+        DataObject& acc = acc2.getContent();
         if (acc.getKey()[1] != 'x')
             acc.setKey("0x" + acc.getKey());
         acc["code"].setString(test::compiler::replaceCode(acc.atKey("code").asString(), _preSolidity));
@@ -258,8 +259,8 @@ DataObject convertDecStateToHex(DataObject const& _data, solContracts const& _pr
         acc["balance"].performModifier(mod_valueToCompactEvenHexPrefixed);
         for (auto& rec : acc["storage"].getSubObjectsUnsafe())
         {
-            rec.performModifier(mod_keyToCompactEvenHexPrefixed);
-            rec.performModifier(mod_valueToCompactEvenHexPrefixed);
+            rec.getContent().performModifier(mod_keyToCompactEvenHexPrefixed);
+            rec.getContent().performModifier(mod_valueToCompactEvenHexPrefixed);
         }
     }
     return tmpD;
@@ -305,9 +306,10 @@ string compareBlockHeaders(DataObject const& _blockA, DataObject const& _blockB,
     _whatField = string();
     ETH_ERROR_REQUIRE_MESSAGE(_blockA.getSubObjects().size() == _blockB.getSubObjects().size(),
         "compareBlockHeaders  _blockA.size() != _blockB.size()");
-    for (auto const& el : _blockA.getSubObjects())
+    for (auto const& el2 : _blockA.getSubObjects())
     {
-        string const testHeaderField = _blockB.getSubObjects().at(k++).asString();
+        DataObject const& el = el2;
+        string const testHeaderField = _blockB.getSubObjects().at(k++)->asString();
         message += cYellow + el.getKey() + cRed + " ";
         if (el.asString() != testHeaderField)
         {
@@ -334,10 +336,10 @@ void readExpectExceptions(DataObject const& _data, std::map<FORK, string>& _out)
     {
         // Parse ">=Frontier" : "EXCEPTION"
         ClientConfig const& cfg = Options::get().getDynamicOptions().getCurrentConfig();
-        std::set<string> forksString = {rec.getKey()};
+        std::set<string> forksString = {rec->getKey()};
         std::vector<FORK> parsedForks = cfg.translateNetworks(forksString);
         for (auto const& el : parsedForks)
-            _out.emplace(el, rec.asString());
+            _out.emplace(el, rec->asString());
     }
 }
 

--- a/retesteth/testStructures/Common.h
+++ b/retesteth/testStructures/Common.h
@@ -45,10 +45,10 @@ void requireJsonFields(
 
 // Compile LLL in code, solidity in code
 // Convert dec fields to hex, add 0x prefix to accounts and storage keys
-DataObject convertDecStateToHex(DataObject const& _data, solContracts const& _preSolidity = solContracts());
+spDataObject convertDecStateToHex(DataObject const& _data, solContracts const& _preSolidity = solContracts());
 
 // Convert dec fields to hex, add 0x prefix to accounts and storage keys
-DataObject convertDecBlockheaderIncompleteToHex(DataObject const& _data);
+spDataObject convertDecBlockheaderIncompleteToHex(DataObject const& _data);
 
 // Make a nice compare result string
 string compareBlockHeaders(DataObject const& _blockA, DataObject const& _blockB, string& _whatField);

--- a/retesteth/testStructures/PrepareChainParams.cpp
+++ b/retesteth/testStructures/PrepareChainParams.cpp
@@ -16,7 +16,7 @@ SetChainParamsArgs prepareChainParams(
     cfg.validateForkAllowed(_net);
 
     spDataObject genesis(new DataObject());
-    (*genesis).copyFrom(cfg.getGenesisTemplate(_net).getCContent());
+    (*genesis).copyFrom(cfg.getGenesisTemplate(_net).getCContent()); // TODO need copy?
     (*genesis)["sealEngine"] = sealEngineToStr(_engine);
 
     (*genesis)["genesis"]["author"] = _env.currentCoinbase().asString();

--- a/retesteth/testStructures/PrepareChainParams.cpp
+++ b/retesteth/testStructures/PrepareChainParams.cpp
@@ -15,13 +15,13 @@ SetChainParamsArgs prepareChainParams(
     ClientConfig const& cfg = Options::get().getDynamicOptions().getCurrentConfig();
     cfg.validateForkAllowed(_net);
 
-    DataObject genesis;
-    genesis = cfg.getGenesisTemplate(_net);
-    genesis["sealEngine"] = sealEngineToStr(_engine);
+    spDataObject genesis(new DataObject());
+    (*genesis).copyFrom(cfg.getGenesisTemplate(_net).getCContent());
+    (*genesis)["sealEngine"] = sealEngineToStr(_engine);
 
-    genesis["genesis"]["author"] = _env.currentCoinbase().asString();
-    genesis["genesis"]["difficulty"] = _env.currentDifficulty().asString();
-    genesis["genesis"]["gasLimit"] = _env.currentGasLimit().asString();
+    (*genesis)["genesis"]["author"] = _env.currentCoinbase().asString();
+    (*genesis)["genesis"]["difficulty"] = _env.currentDifficulty().asString();
+    (*genesis)["genesis"]["gasLimit"] = _env.currentGasLimit().asString();
 
     if (!_env.currentBaseFee().isEmpty())
     {
@@ -30,10 +30,10 @@ SetChainParamsArgs prepareChainParams(
             // Reverse back the baseFee calculation formula for genesis block
             VALUE const& baseFee = _env.currentBaseFee().getCContent();
             VALUE genesisBaseFee = baseFee * 8 / 7;
-            genesis["genesis"]["baseFeePerGas"] = genesisBaseFee.asString();
+            (*genesis)["genesis"]["baseFeePerGas"] = genesisBaseFee.asString();
         }
         else
-            genesis["genesis"]["baseFeePerGas"] = _env.currentBaseFee()->asString();
+            (*genesis)["genesis"]["baseFeePerGas"] = _env.currentBaseFee()->asString();
     }
     else
     {
@@ -43,26 +43,26 @@ SetChainParamsArgs prepareChainParams(
             if (_paramsContext == ParamsContext::StateTests)
             {
                 VALUE genesisBaseFee = 10 * 8 / 7;
-                genesis["genesis"]["baseFeePerGas"] = genesisBaseFee.asString();
+                (*genesis)["genesis"]["baseFeePerGas"] = genesisBaseFee.asString();
             }
             else
-                genesis["genesis"]["baseFeePerGas"] = "0x10";
+                (*genesis)["genesis"]["baseFeePerGas"] = "0x10";
         }
     }
 
     // Convert back 1559 genesis into legacy genesis, when filling 1559 tests
     auto const& additional = Options::getCurrentConfig().cfgFile().additionalForks();
     if (!inArray(additional, _net) && compareFork(_net, CMP::lt, FORK("London")))
-        genesis.atKeyUnsafe("genesis").removeKey("baseFeePerGas");
+        (*genesis).atKeyUnsafe("genesis").removeKey("baseFeePerGas");
 
-    genesis["genesis"]["extraData"] = _env.currentExtraData().asString();
-    genesis["genesis"]["timestamp"] = _env.currentTimestamp().asString();
-    genesis["genesis"]["nonce"] = _env.currentNonce().asString();
-    genesis["genesis"]["mixHash"] = _env.currentMixHash().asString();
+    (*genesis)["genesis"]["extraData"] = _env.currentExtraData().asString();
+    (*genesis)["genesis"]["timestamp"] = _env.currentTimestamp().asString();
+    (*genesis)["genesis"]["nonce"] = _env.currentNonce().asString();
+    (*genesis)["genesis"]["mixHash"] = _env.currentMixHash().asString();
 
     // Because of template might contain preset accounts
     for (auto const& el : _state.accounts())
-        genesis["accounts"].addSubObject(el.second->asDataObject());
+        (*genesis)["accounts"].addSubObject(el.second->asDataObject());
     return SetChainParamsArgs(genesis);
 }
 

--- a/retesteth/testStructures/basetypes/IPADDRESS.cpp
+++ b/retesteth/testStructures/basetypes/IPADDRESS.cpp
@@ -7,7 +7,7 @@ namespace test
 {
 namespace teststruct
 {
-IPADDRESS::IPADDRESS(DataObject const& _ip) : m_data(_ip)
+IPADDRESS::IPADDRESS(DataObject const& _ip) : m_data(_ip.asString())
 {
     size_t pos = _ip.asString().find_last_of(':');
     string address = _ip.asString().substr(0, pos);

--- a/retesteth/testStructures/basetypes/IPADDRESS.h
+++ b/retesteth/testStructures/basetypes/IPADDRESS.h
@@ -11,7 +11,7 @@ namespace teststruct
 struct IPADDRESS : GCP_SPointerBase
 {
     IPADDRESS(DataObject const&);
-    string const& asString() const { return m_data.asString(); }
+    string const& asString() const { return m_data; }
 
     // std container operations
     inline bool operator==(IPADDRESS const& rhs) const { return asString() == rhs.asString(); }
@@ -21,7 +21,7 @@ struct IPADDRESS : GCP_SPointerBase
 
 private:
     IPADDRESS() {}
-    DataObject m_data;
+    string m_data;
 };
 
 typedef GCP_SPointer<IPADDRESS> spIPADDRESS;

--- a/retesteth/testStructures/configs/ClientConfigFile.cpp
+++ b/retesteth/testStructures/configs/ClientConfigFile.cpp
@@ -48,7 +48,7 @@ void ClientConfigFile::initWithData(DataObject const& _data)
         {
             IPADDRESS addr(el);
             if (test::inArray(m_socketAddress, addr))
-                ETH_ERROR_MESSAGE(sErrorPath + "`socketAddress` section contain dublicate element: " + el.asString());
+                ETH_ERROR_MESSAGE(sErrorPath + "`socketAddress` section contain dublicate element: " + el->asString());
             m_socketAddress.push_back(addr);
         }
     }
@@ -103,20 +103,20 @@ void ClientConfigFile::initWithData(DataObject const& _data)
     // Homestead`) According to this order:
     for (auto const& el : _data.atKey("forks").getSubObjects())
     {
-        if (el.asString()[0] == '/' && el.asString()[1] == '/')
+        if (el->asString()[0] == '/' && el->asString()[1] == '/')
             continue;
         if (test::inArray(m_forks, FORK(el)))
-            ETH_ERROR_MESSAGE(sErrorPath + "`forks` section contain dublicate element: " + el.asString());
+            ETH_ERROR_MESSAGE(sErrorPath + "`forks` section contain dublicate element: " + el->asString());
         m_forks.push_back(FORK(el));
     }
 
     // Read additionalForks are allowed fork names to run on this client, but not used in translation
     for (auto const& el : _data.atKey("additionalForks").getSubObjects())
     {
-        if (el.asString()[0] == '/' && el.asString()[1] == '/')
+        if (el->asString()[0] == '/' && el->asString()[1] == '/')
             continue;
         if (test::inArray(m_additionalForks, FORK(el)))
-            ETH_ERROR_MESSAGE(sErrorPath + "`additionalForks` section contain dublicate element: " + el.asString());
+            ETH_ERROR_MESSAGE(sErrorPath + "`additionalForks` section contain dublicate element: " + el->asString());
         m_additionalForks.push_back(FORK(el));
     }
 
@@ -124,9 +124,9 @@ void ClientConfigFile::initWithData(DataObject const& _data)
     // returned from client
     for (auto const& el : _data.atKey("exceptions").getSubObjects())
     {
-        if (m_exceptions.count(el.getKey()))
-            ETH_ERROR_MESSAGE(sErrorPath + "`exceptions` section contain dublicate element: " + el.getKey());
-        m_exceptions[el.getKey()] = el.asString();
+        if (m_exceptions.count(el->getKey()))
+            ETH_ERROR_MESSAGE(sErrorPath + "`exceptions` section contain dublicate element: " + el->getKey());
+        m_exceptions[el->getKey()] = el->asString();
     }
 
     // When sending requests to the client, some of the parameters might be named differently
@@ -135,9 +135,9 @@ void ClientConfigFile::initWithData(DataObject const& _data)
     {
         for (auto const& el : _data.atKey("fieldReplace").getSubObjects())
         {
-            if (m_fieldRaplce.count(el.getKey()))
-                ETH_ERROR_MESSAGE(sErrorPath + "`fieldReplace` section contain dublicate element: " + el.getKey());
-            m_fieldRaplce[el.getKey()] = el.asString();
+            if (m_fieldRaplce.count(el->getKey()))
+                ETH_ERROR_MESSAGE(sErrorPath + "`fieldReplace` section contain dublicate element: " + el->getKey());
+            m_fieldRaplce[el->getKey()] = el->asString();
         }
     }
 

--- a/retesteth/testStructures/configs/FORK.cpp
+++ b/retesteth/testStructures/configs/FORK.cpp
@@ -26,7 +26,7 @@ namespace teststruct
 // If to not use FORK in currentConfig init code.
 // Would be possible to calculate the indexes at constructor time
 // Given the FORK array is small and usage of compares are single lines it shall be fine
-FORK::FORK(DataObject const& _data) : m_data(_data) {}
+FORK::FORK(DataObject const& _data) : m_data(_data.asString()) {}
 
 bool compareFork(FORK const& _left, CMP _t, FORK const& _right)
 {

--- a/retesteth/testStructures/configs/FORK.h
+++ b/retesteth/testStructures/configs/FORK.h
@@ -14,7 +14,7 @@ struct FORK : GCP_SPointerBase
     FORK(char const* _s) : m_data(string(_s)) {}
     FORK(std::string const& _s) : m_data(_s) {}
     FORK(DataObject const&);
-    string const& asString() const { return m_data.asString(); }
+    string const& asString() const { return m_data; }
 
     // std container operations
     inline bool operator==(FORK const& rhs) const { return asString() == rhs.asString(); }
@@ -25,7 +25,7 @@ struct FORK : GCP_SPointerBase
 
 private:
     FORK() {}
-    DataObject m_data;
+    string m_data;
 };
 
 enum class CMP

--- a/retesteth/testStructures/types/BlockchainTests/BlockchainTest.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/BlockchainTest.cpp
@@ -31,7 +31,7 @@ BlockchainTestInFilled::BlockchainTestInFilled(DataObject const& _data)
         if (_data.count("exceptions"))
         {
             for (size_t i = _data.atKey("exceptions").getSubObjects().size(); i > 0; i--)
-                m_exceptions.push_back(_data.atKey("exceptions").getSubObjects().at(i - 1).asString());
+                m_exceptions.push_back(_data.atKey("exceptions").getSubObjects().at(i - 1)->asString());
         }
         requireJsonFields(_data, "BlockchainTestInFilled " + _data.getKey(),
             {{"_info", {{DataType::Object}, jsonField::Required}},
@@ -62,7 +62,7 @@ BlockchainTest::BlockchainTest(DataObject const& _data)
             TestOutputHelper::get().get().testFile().string() + " A test file must contain at least one test!");
         for (auto const& el : _data.getSubObjects())
         {
-            TestOutputHelper::get().setCurrentTestInfo(TestInfo("BlockchainTest", el.getKey()));
+            TestOutputHelper::get().setCurrentTestInfo(TestInfo("BlockchainTest", el->getKey()));
             m_tests.push_back(BlockchainTestInFilled(el));
         }
     }

--- a/retesteth/testStructures/types/BlockchainTests/BlockchainTestFiller.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/BlockchainTestFiller.cpp
@@ -36,8 +36,9 @@ BlockchainTestInFiller::BlockchainTestInFiller(DataObject const& _data)
 
         // Process expect section
         std::set<FORK> knownForks;
-        for (auto const& el : _data.atKey("expect").getSubObjects())
+        for (auto const& el2 : _data.atKey("expect").getSubObjects())
         {
+            DataObject const& el = el2.getCContent();
             m_expects.push_back(el);
             BlockchainTestFillerExpectSection const& expect = m_expects.at(m_expects.size() - 1);
             for (auto const& fork : expect.forks())
@@ -53,7 +54,7 @@ BlockchainTestInFiller::BlockchainTestInFiller(DataObject const& _data)
         if (_data.count("exceptions"))
         {
             for (size_t i = _data.atKey("exceptions").getSubObjects().size(); i > 0; i--)
-                m_exceptions.push_back(_data.atKey("exceptions").getSubObjects().at(i - 1).asString());
+                m_exceptions.push_back(_data.atKey("exceptions").getSubObjects().at(i - 1)->asString());
         }
 
         m_hasAtLeastOneUncle = false;
@@ -90,7 +91,7 @@ BlockchainTestFiller::BlockchainTestFiller(DataObject const& _data)
             TestOutputHelper::get().get().testFile().string() + " A test file must contain at least one test!");
         for (auto const& el : _data.getSubObjects())
         {
-            TestOutputHelper::get().setCurrentTestInfo(TestInfo("BlockchainTestFiller", el.getKey()));
+            TestOutputHelper::get().setCurrentTestInfo(TestInfo("BlockchainTestFiller", el->getKey()));
             m_tests.push_back(BlockchainTestInFiller(el));
         }
     }

--- a/retesteth/testStructures/types/BlockchainTests/Filled/BlockchainTestBlock.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filled/BlockchainTestBlock.cpp
@@ -29,9 +29,9 @@ BlockchainTestBlock::BlockchainTestBlock(DataObject const& _data)
             {
                 for (auto const& tr : _data.atKey("transactionSequence").getSubObjects())
                 {
-                    string const sException = tr.count("exception") ? tr.atKey("exception").asString() : string();
+                    string const sException = tr->count("exception") ? tr->atKey("exception").asString() : string();
                     m_transactionSequence.push_back(
-                        {readTransaction(BYTES(tr.atKey("rawBytes"))), sException});
+                        {readTransaction(BYTES(tr->atKey("rawBytes"))), sException});
                 }
             }
 

--- a/retesteth/testStructures/types/BlockchainTests/Filled/BlockchainTestBlock.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filled/BlockchainTestBlock.cpp
@@ -14,7 +14,8 @@ BlockchainTestBlock::BlockchainTestBlock(DataObject const& _data)
             m_chainName = _data.atKey("chainname").asString();
         if (_data.count("blocknumber"))
         {
-            DataObject tmpD = _data.atKey("blocknumber");
+            DataObject tmpD;
+            tmpD.copyFrom(_data.atKey("blocknumber"));
             tmpD.performModifier(mod_valueToCompactEvenHexPrefixed);
             m_blockNumber = spVALUE(new VALUE(tmpD));
         }

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlock.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlock.cpp
@@ -29,7 +29,7 @@ BlockchainTestFillerBlock::BlockchainTestFillerBlock(DataObject const& _data, No
 
         if (_data.count("blocknumber"))
         {
-            spDataObject tmpD;
+            spDataObject tmpD(new DataObject());
             (*tmpD).copyFrom(_data.atKey("blocknumber"));
             (*tmpD).performModifier(mod_valueToCompactEvenHexPrefixed);
             m_blockNumber = spVALUE(new VALUE(tmpD));

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlock.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlock.cpp
@@ -29,8 +29,9 @@ BlockchainTestFillerBlock::BlockchainTestFillerBlock(DataObject const& _data, No
 
         if (_data.count("blocknumber"))
         {
-            DataObject tmpD = _data.atKey("blocknumber");
-            tmpD.performModifier(mod_valueToCompactEvenHexPrefixed);
+            spDataObject tmpD;
+            (*tmpD).copyFrom(_data.atKey("blocknumber"));
+            (*tmpD).performModifier(mod_valueToCompactEvenHexPrefixed);
             m_blockNumber = spVALUE(new VALUE(tmpD));
         }
 

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlock.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlock.cpp
@@ -51,14 +51,14 @@ BlockchainTestFillerBlock::BlockchainTestFillerBlock(DataObject const& _data, No
         if (_data.count("blockHeader"))
         {
             if (_data.atKey("blockHeader").getSubObjects().size() &&
-                _data.atKey("blockHeader").getSubObjects().at(0).type() == DataType::Object)
+                _data.atKey("blockHeader").getSubObjects().at(0)->type() == DataType::Object)
             {
                 // Read overwrite rules specific to fork
                 for (auto const& rec : _data.atKey("blockHeader").getSubObjects())
                 {
                     // Parse ">=Frontier" : "BlockHeaderOverwrite"
                     ClientConfig const& cfg = Options::get().getDynamicOptions().getCurrentConfig();
-                    std::set<string> forksString = {rec.getKey()};
+                    std::set<string> forksString = {rec->getKey()};
                     std::vector<FORK> parsedForks = cfg.translateNetworks(forksString);
                     for (auto const& el : parsedForks)
                         m_overwriteHeaderByForkMap.emplace(el, spBlockHeaderOverwrite(new BlockHeaderOverwrite(rec)));

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlockHeaderOverwrite.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerBlockHeaderOverwrite.cpp
@@ -8,8 +8,8 @@ namespace teststruct
 {
 BlockHeaderOverwrite::BlockHeaderOverwrite(DataObject const& _data)
 {
-    DataObject tmpD = convertDecBlockheaderIncompleteToHex(_data);
-    if (tmpD.getSubObjects().size() > 0)
+    spDataObject tmpD = convertDecBlockheaderIncompleteToHex(_data);
+    if ((*tmpD).getSubObjects().size() > 0)
         m_blockHeaderIncomplete = spBlockHeaderIncomplete(new BlockHeaderIncomplete(tmpD));
 
     m_relTimeStamp = 0;

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerEnv.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerEnv.cpp
@@ -10,23 +10,25 @@ BlockchainTestFillerEnv::BlockchainTestFillerEnv(DataObject const& _data, SealEn
 {
     try
     {
-        DataObject tmpData = _data;
-        tmpData.performModifier(mod_valueToCompactEvenHexPrefixed);
+        spDataObject tmpData;
+        (*tmpData).copyFrom(_data);
+        (*tmpData).performModifier(mod_valueToCompactEvenHexPrefixed);
 
-        DataObject coinbase = _data.atKey("coinbase");
-        if (coinbase.asString().size() > 1 && coinbase.asString()[1] != 'x')
-            coinbase = "0x" + coinbase.asString();
+        spDataObject coinbase;
+        (*coinbase).copyFrom(_data.atKey("coinbase"));
+        if (coinbase->asString().size() > 1 && coinbase->asString()[1] != 'x')
+            (*coinbase) = "0x" + coinbase->asString();
         m_currentCoinbase = spFH20(new FH20(coinbase));
-        m_currentDifficulty = spVALUE(new VALUE(tmpData.atKey("difficulty")));
-        m_currentGasLimit = spVALUE(new VALUE(tmpData.atKey("gasLimit")));
+        m_currentDifficulty = spVALUE(new VALUE(tmpData->atKey("difficulty")));
+        m_currentGasLimit = spVALUE(new VALUE(tmpData->atKey("gasLimit")));
         if (m_currentGasLimit.getCContent() > dev::bigint("0x7fffffffffffffff"))
             throw test::UpwardsException("currentGasLimit must be < 0x7fffffffffffffff");
 
-        if (tmpData.count("baseFeePerGas"))
-            m_currentBaseFee = spVALUE(new VALUE(tmpData.atKey("baseFeePerGas")));
+        if (tmpData->count("baseFeePerGas"))
+            m_currentBaseFee = spVALUE(new VALUE(tmpData->atKey("baseFeePerGas")));
 
-        m_currentNumber = spVALUE(new VALUE(tmpData.atKey("number")));
-        m_currentTimestamp = spVALUE(new VALUE(tmpData.atKey("timestamp")));
+        m_currentNumber = spVALUE(new VALUE(tmpData->atKey("number")));
+        m_currentTimestamp = spVALUE(new VALUE(tmpData->atKey("timestamp")));
         m_previousHash = spFH32(new FH32(_data.atKey("parentHash")));
         m_currentExtraData = spBYTES(new BYTES(_data.atKey("extraData")));
 

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerEnv.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerEnv.cpp
@@ -10,11 +10,11 @@ BlockchainTestFillerEnv::BlockchainTestFillerEnv(DataObject const& _data, SealEn
 {
     try
     {
-        spDataObject tmpData;
+        spDataObject tmpData(new DataObject());
         (*tmpData).copyFrom(_data);
         (*tmpData).performModifier(mod_valueToCompactEvenHexPrefixed);
 
-        spDataObject coinbase;
+        spDataObject coinbase(new DataObject());
         (*coinbase).copyFrom(_data.atKey("coinbase"));
         if (coinbase->asString().size() > 1 && coinbase->asString()[1] != 'x')
             (*coinbase) = "0x" + coinbase->asString();

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerTransaction.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerTransaction.cpp
@@ -16,8 +16,8 @@ BlockchainTestFillerTransaction::BlockchainTestFillerTransaction(DataObject cons
         if (_data.count("expectException"))
             readExpectExceptions(_data.atKey("expectException"), m_expectExceptions);
 
-        spDataObject tmpD;
-        tmpD.getContent().copyFrom(_data);
+        spDataObject tmpD(new DataObject());
+        (*tmpD).copyFrom(_data);
 
         if ((*tmpD).count("secretKey") && (*tmpD).atKey("nonce").asString() == "auto")
         {
@@ -40,7 +40,7 @@ BlockchainTestFillerTransaction::BlockchainTestFillerTransaction(DataObject cons
         (*tmpD).performModifier(mod_valueToCompactEvenHexPrefixed);
 
         // fix 0x prefix on 'to' key
-        spDataObject dTo;
+        spDataObject dTo(new DataObject());
         (*dTo).copyFrom(_data.atKey("to"));
         string const& to = _data.atKey("to").asString();
         if (to.size() > 1 && to[1] != 'x')
@@ -51,7 +51,7 @@ BlockchainTestFillerTransaction::BlockchainTestFillerTransaction(DataObject cons
         (*tmpD)["data"] = test::compiler::replaceCode(_data.atKey("data").asString());
 
         if (_data.count("accessList"))
-            (*tmpD).atKeyPointer("accessList").getContent().copyFrom(_data.atKey("accessList"));
+            (*tmpD)["accessList"].copyFrom(_data.atKey("accessList"));
 
         m_transaction = readTransaction(tmpD);
     }

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerTransaction.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerTransaction.cpp
@@ -16,40 +16,42 @@ BlockchainTestFillerTransaction::BlockchainTestFillerTransaction(DataObject cons
         if (_data.count("expectException"))
             readExpectExceptions(_data.atKey("expectException"), m_expectExceptions);
 
-        DataObject tmpD = _data;
+        spDataObject tmpD;
+        tmpD.getContent().copyFrom(_data);
 
-        if (tmpD.count("secretKey") && tmpD.atKey("nonce").asString() == "auto")
+        if ((*tmpD).count("secretKey") && (*tmpD).atKey("nonce").asString() == "auto")
         {
-            dev::Secret priv(tmpD.atKey("secretKey").asString());
+            dev::Secret priv((*tmpD).atKey("secretKey").asString());
             dev::Address key = dev::toAddress(priv);
             if (_nonceMap.count("0x" + key.hex()))
             {
-                tmpD.atKeyUnsafe("nonce").setString(_nonceMap.at("0x" + key.hex())->asDecString());
+                (*tmpD).atKeyUnsafe("nonce").setString(_nonceMap.at("0x" + key.hex())->asDecString());
                 _nonceMap["0x" + key.hex()].getContent()++;
             }
             else
                 ETH_ERROR_MESSAGE("Parsing tx.nonce `auto` can't find tx.origin in nonce map!");
         }
 
-        tmpD.removeKey("data");
-        tmpD.removeKey("to");
-        tmpD.removeKey("expectException");
-        if (tmpD.count("accessList"))
-            tmpD.removeKey("accessList");
-        tmpD.performModifier(mod_valueToCompactEvenHexPrefixed);
+        (*tmpD).removeKey("data");
+        (*tmpD).removeKey("to");
+        (*tmpD).removeKey("expectException");
+        if (tmpD->count("accessList"))
+            (*tmpD).removeKey("accessList");
+        (*tmpD).performModifier(mod_valueToCompactEvenHexPrefixed);
 
         // fix 0x prefix on 'to' key
-        DataObject dTo = _data.atKey("to");
+        spDataObject dTo;
+        (*dTo).copyFrom(_data.atKey("to"));
         string const& to = _data.atKey("to").asString();
         if (to.size() > 1 && to[1] != 'x')
-            dTo = "0x" + _data.atKey("to").asString();
-        tmpD["to"] = dTo;
+            *dTo = "0x" + _data.atKey("to").asString();
+        (*tmpD).atKeyPointer("to") = dTo;
 
         // Compile LLL in transaction data into byte code if not already
-        tmpD["data"] = test::compiler::replaceCode(_data.atKey("data").asString());
+        (*tmpD)["data"] = test::compiler::replaceCode(_data.atKey("data").asString());
 
         if (_data.count("accessList"))
-            tmpD["accessList"] = _data.atKey("accessList");
+            (*tmpD).atKeyPointer("accessList").getContent().copyFrom(_data.atKey("accessList"));
 
         m_transaction = readTransaction(tmpD);
     }

--- a/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerUncle.cpp
+++ b/retesteth/testStructures/types/BlockchainTests/Filler/BlockchainTestFillerUncle.cpp
@@ -53,7 +53,8 @@ BlockchainTestFillerUncle::BlockchainTestFillerUncle(DataObject const& _data)
 
         // Fields that are to overwrite in uncle's header that will be constructed by test
         // map 'fieldName' -> 'field new value'
-        DataObject tmpD = convertDecBlockheaderIncompleteToHex(_data);
+        spDataObject _tmpD = convertDecBlockheaderIncompleteToHex(_data);
+        DataObject& tmpD = *_tmpD;
         tmpD.removeKey("populateFromBlock");                // BlockchainTestFiller fields
         tmpD.removeKey("sameAsPreviousBlockUncle");         // BlockchainTestFiller fields
         tmpD.removeKey("sameAsBlock");                      // BlockchainTestFiller fields

--- a/retesteth/testStructures/types/Ethereum/Account.cpp
+++ b/retesteth/testStructures/types/Ethereum/Account.cpp
@@ -33,21 +33,21 @@ Account::Account(DataObject const& _data)
          {"storage", {{DataType::Object}, jsonField::Required}}});
 }
 
-const DataObject Account::asDataObject(ExportOrder _order) const
+spDataObject Account::asDataObject(ExportOrder _order) const
 {
-    DataObject out;
+    spDataObject out(new DataObject());
     string const& addr = m_address->asString();
-    out["balance"] = m_balance->asString();
-    out["code"] = m_code->asString();
-    out["nonce"] = m_nonce->asString();
-    out["storage"] = m_storage->asDataObject();
-    out.setKey(addr);
+    (*out)["balance"] = m_balance->asString();
+    (*out)["code"] = m_code->asString();
+    (*out)["nonce"] = m_nonce->asString();
+    (*out).atKeyPointer("storage") = m_storage->asDataObject();
+    (*out).setKey(addr);
 
     if (_order == ExportOrder::OldStyle)
     {
-        out.setKeyPos("code", 0);
-        out.setKeyPos("nonce", 1);
-        out.setKeyPos("balance", 2);
+        (*out).setKeyPos("code", 0);
+        (*out).setKeyPos("nonce", 1);
+        (*out).setKeyPos("balance", 2);
     }
     return out;
 }

--- a/retesteth/testStructures/types/Ethereum/Account.h
+++ b/retesteth/testStructures/types/Ethereum/Account.h
@@ -16,7 +16,7 @@ struct Account : AccountBase
 {
     Account(DataObject const&);
     Account(FH20 const& _addr, VALUE const& _balance, VALUE const& _nonce, BYTES const& _code, Storage const& _storage);
-    DataObject const asDataObject(ExportOrder order = ExportOrder::Default) const override;
+    spDataObject asDataObject(ExportOrder order = ExportOrder::Default) const override;
 
 private:
     Account() {}

--- a/retesteth/testStructures/types/Ethereum/AccountIncomplete.cpp
+++ b/retesteth/testStructures/types/Ethereum/AccountIncomplete.cpp
@@ -33,9 +33,10 @@ AccountIncomplete::AccountIncomplete(DataObject const& _data)
     ETH_ERROR_REQUIRE_MESSAGE(_data.getSubObjects().size() > 0, "AccountIncomplete must have at least one object!");
 }
 
-const DataObject AccountIncomplete::asDataObject(ExportOrder) const
+spDataObject AccountIncomplete::asDataObject(ExportOrder) const
 {
-    DataObject out;
+    spDataObject _out(new DataObject());
+    DataObject& out = _out.getContent();
     string const& addr = m_address->asString();
     if (!m_balance.isEmpty())
         out["balance"] = m_balance->asString();
@@ -44,11 +45,11 @@ const DataObject AccountIncomplete::asDataObject(ExportOrder) const
     if (!m_code.isEmpty())
         out["code"] = m_code->asString();
     if (!m_storage.isEmpty())
-        out["storage"] = m_storage->asDataObject();
+        out.atKeyPointer("storage") = m_storage->asDataObject();
     if (m_shouldNotExist)
         out["shouldnotexist"] = "1";
     out.setKey(addr);
-    return out;
+    return _out;
 }
 
 

--- a/retesteth/testStructures/types/Ethereum/AccountIncomplete.h
+++ b/retesteth/testStructures/types/Ethereum/AccountIncomplete.h
@@ -16,7 +16,7 @@ struct AccountIncomplete : AccountBase
 {
     AccountIncomplete(DataObject const&);
     void setBalance(VALUE const& _balance) { m_balance = spVALUE(new VALUE(_balance)); }
-    DataObject const asDataObject(ExportOrder) const override;
+    spDataObject asDataObject(ExportOrder) const override;
 };
 
 typedef GCP_SPointer<AccountIncomplete> spAccountIncomplete;

--- a/retesteth/testStructures/types/Ethereum/Base/AccountBase.h
+++ b/retesteth/testStructures/types/Ethereum/Base/AccountBase.h
@@ -26,7 +26,7 @@ struct AccountBase : GCP_SPointerBase
     BYTES const& code() const { return m_code; }
     FH20 const& address() const { return m_address; }
 
-    virtual DataObject const asDataObject(ExportOrder order = ExportOrder::Default) const = 0;
+    virtual spDataObject asDataObject(ExportOrder order = ExportOrder::Default) const = 0;
     virtual ~AccountBase() {}
 
 protected:

--- a/retesteth/testStructures/types/Ethereum/Base/StateBase.h
+++ b/retesteth/testStructures/types/Ethereum/Base/StateBase.h
@@ -12,7 +12,7 @@ namespace teststruct
 struct StateBase : GCP_SPointerBase
 {
     std::map<FH20, spAccountBase> const& accounts() const { return m_accounts; }
-    virtual DataObject const asDataObject(ExportOrder order = ExportOrder::Default) const = 0;
+    virtual spDataObject asDataObject(ExportOrder order = ExportOrder::Default) const = 0;
     virtual ~StateBase() {}
 
 protected:

--- a/retesteth/testStructures/types/Ethereum/BlockHeader.h
+++ b/retesteth/testStructures/types/Ethereum/BlockHeader.h
@@ -23,7 +23,7 @@ struct BlockHeader : GCP_SPointerBase
 {
     virtual ~BlockHeader(){/* all smart pointers */};
 
-    virtual DataObject const asDataObject() const = 0;
+    virtual spDataObject asDataObject() const = 0;
     virtual dev::RLPStream const asRLPStream() const = 0;
     virtual BlockType type() const = 0;
 

--- a/retesteth/testStructures/types/Ethereum/BlockHeader1559.cpp
+++ b/retesteth/testStructures/types/Ethereum/BlockHeader1559.cpp
@@ -133,26 +133,26 @@ BlockHeader1559::BlockHeader1559(dev::RLP const& _rlp)
     recalculateHash();
 }
 
-const DataObject BlockHeader1559::asDataObject() const
+spDataObject BlockHeader1559::asDataObject() const
 {
-    DataObject out;
-    out["bloom"] = m_logsBloom->asString();
-    out["coinbase"] = m_author->asString();
-    out["difficulty"] = m_difficulty->asString();
-    out["extraData"] = m_extraData->asString();
-    out["gasLimit"] = m_gasLimit->asString();
-    out["gasUsed"] = m_gasUsed->asString();
-    out["hash"] = m_hash->asString();
-    out["mixHash"] = m_mixHash->asString();
-    out["nonce"] = m_nonce->asString();
-    out["number"] = m_number->asString();
-    out["parentHash"] = m_parentHash->asString();
-    out["receiptTrie"] = m_receiptsRoot->asString();
-    out["stateRoot"] = m_stateRoot->asString();
-    out["timestamp"] = m_timestamp->asString();
-    out["transactionsTrie"] = m_transactionsRoot->asString();
-    out["uncleHash"] = m_sha3Uncles->asString();
-    out["baseFeePerGas"] = m_baseFee->asString();
+    spDataObject out(new DataObject());
+    (*out)["bloom"] = m_logsBloom->asString();
+    (*out)["coinbase"] = m_author->asString();
+    (*out)["difficulty"] = m_difficulty->asString();
+    (*out)["extraData"] = m_extraData->asString();
+    (*out)["gasLimit"] = m_gasLimit->asString();
+    (*out)["gasUsed"] = m_gasUsed->asString();
+    (*out)["hash"] = m_hash->asString();
+    (*out)["mixHash"] = m_mixHash->asString();
+    (*out)["nonce"] = m_nonce->asString();
+    (*out)["number"] = m_number->asString();
+    (*out)["parentHash"] = m_parentHash->asString();
+    (*out)["receiptTrie"] = m_receiptsRoot->asString();
+    (*out)["stateRoot"] = m_stateRoot->asString();
+    (*out)["timestamp"] = m_timestamp->asString();
+    (*out)["transactionsTrie"] = m_transactionsRoot->asString();
+    (*out)["uncleHash"] = m_sha3Uncles->asString();
+    (*out)["baseFeePerGas"] = m_baseFee->asString();
     return out;
 }
 

--- a/retesteth/testStructures/types/Ethereum/BlockHeader1559.h
+++ b/retesteth/testStructures/types/Ethereum/BlockHeader1559.h
@@ -17,7 +17,7 @@ struct BlockHeader1559 : BlockHeader
     BlockHeader1559(DataObject const&);
     BlockHeader1559(dev::RLP const&);
 
-    DataObject const asDataObject() const override;
+    spDataObject asDataObject() const override;
     dev::RLPStream const asRLPStream() const override;
     BlockType type() const override { return BlockType::BlockHeader1559; }
 

--- a/retesteth/testStructures/types/Ethereum/BlockHeaderIncomplete.cpp
+++ b/retesteth/testStructures/types/Ethereum/BlockHeaderIncomplete.cpp
@@ -92,7 +92,8 @@ BlockHeaderIncomplete::BlockHeaderIncomplete(DataObject const& _data)
 
 spBlockHeader BlockHeaderIncomplete::overwriteBlockHeader(spBlockHeader const& _header) const
 {
-    DataObject overwrite = _header->asDataObject();
+    spDataObject _overwrite = _header->asDataObject();
+    DataObject& overwrite = _overwrite.getContent();
     if (!m_author.isEmpty())
         overwrite["author"] = m_author->asString();
     if (!m_difficulty.isEmpty())

--- a/retesteth/testStructures/types/Ethereum/BlockHeaderLegacy.cpp
+++ b/retesteth/testStructures/types/Ethereum/BlockHeaderLegacy.cpp
@@ -130,7 +130,7 @@ BlockHeaderLegacy::BlockHeaderLegacy(dev::RLP const& _rlp)
 
 spDataObject BlockHeaderLegacy::asDataObject() const
 {
-    spDataObject out;
+    spDataObject out (new DataObject());
     (*out)["bloom"] = m_logsBloom->asString();
     (*out)["coinbase"] = m_author->asString();
     (*out)["difficulty"] = m_difficulty->asString();

--- a/retesteth/testStructures/types/Ethereum/BlockHeaderLegacy.cpp
+++ b/retesteth/testStructures/types/Ethereum/BlockHeaderLegacy.cpp
@@ -128,25 +128,25 @@ BlockHeaderLegacy::BlockHeaderLegacy(dev::RLP const& _rlp)
     recalculateHash();
 }
 
-const DataObject BlockHeaderLegacy::asDataObject() const
+spDataObject BlockHeaderLegacy::asDataObject() const
 {
-    DataObject out;
-    out["bloom"] = m_logsBloom->asString();
-    out["coinbase"] = m_author->asString();
-    out["difficulty"] = m_difficulty->asString();
-    out["extraData"] = m_extraData->asString();
-    out["gasLimit"] = m_gasLimit->asString();
-    out["gasUsed"] = m_gasUsed->asString();
-    out["hash"] = m_hash->asString();
-    out["mixHash"] = m_mixHash->asString();
-    out["nonce"] = m_nonce->asString();
-    out["number"] = m_number->asString();
-    out["parentHash"] = m_parentHash->asString();
-    out["receiptTrie"] = m_receiptsRoot->asString();
-    out["stateRoot"] = m_stateRoot->asString();
-    out["timestamp"] = m_timestamp->asString();
-    out["transactionsTrie"] = m_transactionsRoot->asString();
-    out["uncleHash"] = m_sha3Uncles->asString();
+    spDataObject out;
+    (*out)["bloom"] = m_logsBloom->asString();
+    (*out)["coinbase"] = m_author->asString();
+    (*out)["difficulty"] = m_difficulty->asString();
+    (*out)["extraData"] = m_extraData->asString();
+    (*out)["gasLimit"] = m_gasLimit->asString();
+    (*out)["gasUsed"] = m_gasUsed->asString();
+    (*out)["hash"] = m_hash->asString();
+    (*out)["mixHash"] = m_mixHash->asString();
+    (*out)["nonce"] = m_nonce->asString();
+    (*out)["number"] = m_number->asString();
+    (*out)["parentHash"] = m_parentHash->asString();
+    (*out)["receiptTrie"] = m_receiptsRoot->asString();
+    (*out)["stateRoot"] = m_stateRoot->asString();
+    (*out)["timestamp"] = m_timestamp->asString();
+    (*out)["transactionsTrie"] = m_transactionsRoot->asString();
+    (*out)["uncleHash"] = m_sha3Uncles->asString();
     return out;
 }
 

--- a/retesteth/testStructures/types/Ethereum/BlockHeaderLegacy.h
+++ b/retesteth/testStructures/types/Ethereum/BlockHeaderLegacy.h
@@ -18,7 +18,7 @@ struct BlockHeaderLegacy : BlockHeader
     BlockHeaderLegacy(dev::RLP const&);
     virtual ~BlockHeaderLegacy(){/* all smart pointers */};
 
-    virtual DataObject const asDataObject() const override;
+    virtual spDataObject asDataObject() const override;
     virtual dev::RLPStream const asRLPStream() const override;
     virtual BlockType type() const override { return BlockType::BlockHeaderLegacy; }
 

--- a/retesteth/testStructures/types/Ethereum/State.cpp
+++ b/retesteth/testStructures/types/Ethereum/State.cpp
@@ -53,18 +53,18 @@ bool State::hasAccount(FH20 const& _address) const
     return m_accounts.count(_address);
 }
 
-const DataObject State::asDataObject(ExportOrder _order) const
+spDataObject State::asDataObject(ExportOrder _order) const
 {
-    DataObject out;
+    spDataObject out(new DataObject());
     if (_order == ExportOrder::OldStyle)
     {
         for (auto const& el : m_order)
-            out.addSubObject(m_accounts.at(el)->asDataObject(_order));
+            (*out).addSubObject(m_accounts.at(el)->asDataObject(_order));
     }
     else
     {
         for (auto const& el : m_accounts)
-            out.addSubObject(el.second->asDataObject());
+            (*out).addSubObject(el.second->asDataObject());
     }
     return out;
 }

--- a/retesteth/testStructures/types/Ethereum/State.cpp
+++ b/retesteth/testStructures/types/Ethereum/State.cpp
@@ -24,7 +24,7 @@ State::State(DataObject const& _data)
     {
         for (auto const& el : _data.getSubObjects())
         {
-            FH20 key(el.getKey());
+            FH20 key(el->getKey());
             m_order.push_back(key);
             m_accounts[key] = spAccountBase(new Account(el));
         }

--- a/retesteth/testStructures/types/Ethereum/State.h
+++ b/retesteth/testStructures/types/Ethereum/State.h
@@ -21,7 +21,7 @@ struct State : StateBase
     bool hasAccount(Account const& _account) const;
     bool hasAccount(FH20 const& _address) const;
 
-    DataObject const asDataObject(ExportOrder order = ExportOrder::Default) const override;
+    spDataObject asDataObject(ExportOrder order = ExportOrder::Default) const override;
 
 private:
     std::vector<FH20> m_order;

--- a/retesteth/testStructures/types/Ethereum/StateIncomplete.cpp
+++ b/retesteth/testStructures/types/Ethereum/StateIncomplete.cpp
@@ -17,8 +17,9 @@ StateIncomplete::StateIncomplete(DataObject const& _data, DataRequier _req)
             // Convertion is here so not to repeat convertion in State and Blockchain tests
             // Convert Expect Section IncompletePostState fields to hex, account keys add `0x` prefix
             // Code field add `0x` prefix, storage key:value add `0x` prefix, coverted to hex
-            DataObject tmpD = _data;
-            for (auto& acc2 : tmpD.getSubObjectsUnsafe())
+            spDataObject tmpD(new DataObject());
+            (*tmpD).copyFrom(_data);
+            for (auto& acc2 : (*tmpD).getSubObjectsUnsafe())
             {
                 DataObject& acc = acc2.getContent();
                 string const& key = acc2->getKey();
@@ -37,7 +38,7 @@ StateIncomplete::StateIncomplete(DataObject const& _data, DataRequier _req)
                         rec.getContent().performModifier(mod_valueToCompactEvenHexPrefixed);
                     }
             }
-            for (auto const& el : tmpD.getSubObjects())
+            for (auto const& el : tmpD->getSubObjects())
                 m_accounts[FH20(el->getKey())] = spAccountBase(new AccountIncomplete(el));
         }
         else
@@ -52,11 +53,11 @@ StateIncomplete::StateIncomplete(DataObject const& _data, DataRequier _req)
     }
 }
 
-const DataObject StateIncomplete::asDataObject(ExportOrder) const
+spDataObject StateIncomplete::asDataObject(ExportOrder) const
 {
-    DataObject out;
+    spDataObject out(new DataObject());
     for (auto const& el : m_accounts)
-        out.addSubObject(el.second->asDataObject());
+        (*out).addSubObject(el.second->asDataObject());
     return out;
 }
 

--- a/retesteth/testStructures/types/Ethereum/StateIncomplete.cpp
+++ b/retesteth/testStructures/types/Ethereum/StateIncomplete.cpp
@@ -18,9 +18,10 @@ StateIncomplete::StateIncomplete(DataObject const& _data, DataRequier _req)
             // Convert Expect Section IncompletePostState fields to hex, account keys add `0x` prefix
             // Code field add `0x` prefix, storage key:value add `0x` prefix, coverted to hex
             DataObject tmpD = _data;
-            for (auto& acc : tmpD.getSubObjectsUnsafe())
+            for (auto& acc2 : tmpD.getSubObjectsUnsafe())
             {
-                string const& key = acc.getKey();
+                DataObject& acc = acc2.getContent();
+                string const& key = acc2->getKey();
                 if ((key.size() > 2 && (key[0] != '0' || key[1] != 'x')))
                     acc.setKey("0x" + acc.getKey());
                 if (acc.count("balance"))
@@ -32,17 +33,17 @@ StateIncomplete::StateIncomplete(DataObject const& _data, DataRequier _req)
                 if (acc.count("storage"))
                     for (auto& rec : acc["storage"].getSubObjectsUnsafe())
                     {
-                        rec.performModifier(mod_keyToCompactEvenHexPrefixed);
-                        rec.performModifier(mod_valueToCompactEvenHexPrefixed);
+                        rec.getContent().performModifier(mod_keyToCompactEvenHexPrefixed);
+                        rec.getContent().performModifier(mod_valueToCompactEvenHexPrefixed);
                     }
             }
             for (auto const& el : tmpD.getSubObjects())
-                m_accounts[FH20(el.getKey())] = spAccountBase(new AccountIncomplete(el));
+                m_accounts[FH20(el->getKey())] = spAccountBase(new AccountIncomplete(el));
         }
         else
         {
             for (auto const& el : _data.getSubObjects())
-                m_accounts[FH20(el.getKey())] = spAccountBase(new AccountIncomplete(el));
+                m_accounts[FH20(el->getKey())] = spAccountBase(new AccountIncomplete(el));
         }
     }
     catch (std::exception const& _ex)

--- a/retesteth/testStructures/types/Ethereum/StateIncomplete.h
+++ b/retesteth/testStructures/types/Ethereum/StateIncomplete.h
@@ -20,7 +20,7 @@ struct StateIncomplete : StateBase
 {
     StateIncomplete(DataObject const&, DataRequier req = DataRequier::ONLYHEX);
     void correctMiningReward(FH20 const& _coinbase, VALUE const& _reward);
-    DataObject const asDataObject(ExportOrder _order = ExportOrder::Default) const override;
+    spDataObject asDataObject(ExportOrder _order = ExportOrder::Default) const override;
 
 private:
     StateIncomplete(){};

--- a/retesteth/testStructures/types/Ethereum/Storage.cpp
+++ b/retesteth/testStructures/types/Ethereum/Storage.cpp
@@ -10,7 +10,7 @@ Storage::Storage(DataObject const& _data)
     {
         DataObject tmpKey;
         tmpKey.setKey("Storage record in storage");  // Hint
-        tmpKey.setString(el.getKey());
+        tmpKey.setString(el->getKey());
         spVALUE key(new VALUE(tmpKey));
         spVALUE val(new VALUE(el));
         m_map[key->asString()] = {key, val};

--- a/retesteth/testStructures/types/Ethereum/Storage.cpp
+++ b/retesteth/testStructures/types/Ethereum/Storage.cpp
@@ -24,13 +24,13 @@ void Storage::merge(Storage const& _storage)
         m_map[record.first] = record.second;
 }
 
-const DataObject Storage::asDataObject() const
+spDataObject Storage::asDataObject() const
 {
-    DataObject out(DataType::Object);
+    spDataObject out(new DataObject(DataType::Object));
     for (auto const& el : m_map)
     {
         StorageRecord const& record = el.second;
-        out[std::get<0>(record)->asString()] = std::get<1>(record)->asString();
+        (*out)[std::get<0>(record)->asString()] = std::get<1>(record)->asString();
     }
     return out;
 }

--- a/retesteth/testStructures/types/Ethereum/Storage.h
+++ b/retesteth/testStructures/types/Ethereum/Storage.h
@@ -22,7 +22,7 @@ struct Storage : GCP_SPointerBase
         assert(m_map.count(_key.asString()));
         return std::get<1>(m_map.at(_key.asString()));
     }
-    DataObject const asDataObject() const;
+    spDataObject asDataObject() const;
     void merge(Storage const& _storage);
 
 private:

--- a/retesteth/testStructures/types/Ethereum/Transaction.h
+++ b/retesteth/testStructures/types/Ethereum/Transaction.h
@@ -22,7 +22,7 @@ struct Transaction : GCP_SPointerBase
 {
     // Transaction Interface
     virtual TransactionType type() const = 0;
-    virtual DataObject const asDataObject(ExportOrder _order = ExportOrder::Default) const = 0;
+    virtual spDataObject asDataObject(ExportOrder _order = ExportOrder::Default) const = 0;
     virtual ~Transaction(){ /* all fields are smart pointers */ };
 
     // Common transaction data

--- a/retesteth/testStructures/types/Ethereum/TransactionAccessList.cpp
+++ b/retesteth/testStructures/types/Ethereum/TransactionAccessList.cpp
@@ -190,7 +190,7 @@ spDataObject TransactionAccessList::asDataObject(ExportOrder _order) const
     spDataObject out = TransactionLegacy::asDataObject(_order);
 
     (*out)["chainId"] = "0x01";
-    (*out)["accessList"].copyFrom(m_accessList->asDataObject());
+    (*out).atKeyPointer("accessList") = m_accessList->asDataObject();
     (*out)["type"] = "0x01";
     if (_order == ExportOrder::ToolStyle)
     {

--- a/retesteth/testStructures/types/Ethereum/TransactionAccessList.cpp
+++ b/retesteth/testStructures/types/Ethereum/TransactionAccessList.cpp
@@ -152,12 +152,9 @@ void TransactionAccessList::buildVRS(VALUE const& _secret)
     ETH_FAIL_REQUIRE_MESSAGE(
         sigStruct.isValid(), TestOutputHelper::get().testName() + " Could not construct transaction signature!");
 
-    DataObject v = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.v), 1));
-    DataObject r = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.r)));
-    DataObject s = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.s)));
-    m_v = spVALUE(new VALUE(v));
-    m_r = spVALUE(new VALUE(r));
-    m_s = spVALUE(new VALUE(s));
+    m_v = spVALUE(new VALUE(dev::toCompactHexPrefixed(dev::u256(sigStruct.v), 1)));
+    m_r = spVALUE(new VALUE(dev::toCompactHexPrefixed(dev::u256(sigStruct.r))));
+    m_s = spVALUE(new VALUE(dev::toCompactHexPrefixed(dev::u256(sigStruct.s))));
     rebuildRLP();
 }
 
@@ -188,19 +185,19 @@ void TransactionAccessList::streamHeader(dev::RLPStream& _s) const
     _s.appendRaw(accessList.out());
 }
 
-DataObject const TransactionAccessList::asDataObject(ExportOrder _order) const
+spDataObject TransactionAccessList::asDataObject(ExportOrder _order) const
 {
-    DataObject out = TransactionLegacy::asDataObject(_order);
+    spDataObject out = TransactionLegacy::asDataObject(_order);
 
-    out["chainId"] = "0x01";
-    out["accessList"] = m_accessList->asDataObject();
-    out["type"] = "0x01";
+    (*out)["chainId"] = "0x01";
+    (*out)["accessList"].copyFrom(m_accessList->asDataObject());
+    (*out)["type"] = "0x01";
     if (_order == ExportOrder::ToolStyle)
     {
-        out["chainId"] = "0x1";
-        out["type"] = "0x1";
+        (*out)["chainId"] = "0x1";
+        (*out)["type"] = "0x1";
         if (!m_secretKey.isEmpty() && m_secretKey.getCContent() != 0)
-            out["secretKey"] = m_secretKey->asString();
+            (*out)["secretKey"] = m_secretKey->asString();
     }
     return out;
 }

--- a/retesteth/testStructures/types/Ethereum/TransactionAccessList.h
+++ b/retesteth/testStructures/types/Ethereum/TransactionAccessList.h
@@ -14,7 +14,7 @@ struct TransactionAccessList : TransactionLegacy
     TransactionAccessList(BYTES const&);
     TransactionAccessList(dev::RLP const&);
 
-    DataObject const asDataObject(ExportOrder _order = ExportOrder::Default) const override;
+    spDataObject asDataObject(ExportOrder _order = ExportOrder::Default) const override;
     TransactionType type() const override { return TransactionType::ACCESSLIST; }
 
 protected:

--- a/retesteth/testStructures/types/Ethereum/TransactionBaseFee.cpp
+++ b/retesteth/testStructures/types/Ethereum/TransactionBaseFee.cpp
@@ -157,12 +157,9 @@ void TransactionBaseFee::buildVRS(VALUE const& _secret)
     ETH_FAIL_REQUIRE_MESSAGE(
         sigStruct.isValid(), TestOutputHelper::get().testName() + " Could not construct transaction signature!");
 
-    DataObject v = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.v), 1));
-    DataObject r = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.r)));
-    DataObject s = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.s)));
-    m_v = spVALUE(new VALUE(v));
-    m_r = spVALUE(new VALUE(r));
-    m_s = spVALUE(new VALUE(s));
+    m_v = spVALUE(new VALUE(dev::toCompactHexPrefixed(dev::u256(sigStruct.v), 1)));
+    m_r = spVALUE(new VALUE(dev::toCompactHexPrefixed(dev::u256(sigStruct.r))));
+    m_s = spVALUE(new VALUE(dev::toCompactHexPrefixed(dev::u256(sigStruct.s))));
     rebuildRLP();
 }
 
@@ -197,62 +194,62 @@ void TransactionBaseFee::streamHeader(dev::RLPStream& _s) const
     _s.appendRaw(accessList.out());
 }
 
-DataObject const TransactionBaseFee::asDataObject(ExportOrder _order) const
+spDataObject TransactionBaseFee::asDataObject(ExportOrder _order) const
 {
     // Because we don't use gas_price field need to explicitly output
-    DataObject out;
-    out["data"] = m_data->asString();
-    out["gasLimit"] = m_gasLimit->asString();
-    out["nonce"] = m_nonce->asString();
+    spDataObject out(new DataObject());
+    (*out)["data"] = m_data->asString();
+    (*out)["gasLimit"] = m_gasLimit->asString();
+    (*out)["nonce"] = m_nonce->asString();
     if (m_creation)
     {
         if (_order != ExportOrder::ToolStyle)
-            out["to"] = "";
+            (*out)["to"] = "";
     }
     else
-        out["to"] = m_to->asString();
-    out["value"] = m_value->asString();
-    out["v"] = m_v->asString();
-    out["r"] = m_r->asString();
-    out["s"] = m_s->asString();
+        (*out)["to"] = m_to->asString();
+    (*out)["value"] = m_value->asString();
+    (*out)["v"] = m_v->asString();
+    (*out)["r"] = m_r->asString();
+    (*out)["s"] = m_s->asString();
     if (_order == ExportOrder::ToolStyle)
     {
-        out.performModifier(mod_removeLeadingZerosFromHexValues, {"data", "to"});
-        out.renameKey("gasLimit", "gas");
-        out.renameKey("data", "input");
+        (*out).performModifier(mod_removeLeadingZerosFromHexValues, {"data", "to"});
+        (*out).renameKey("gasLimit", "gas");
+        (*out).renameKey("data", "input");
         if (!m_secretKey.isEmpty() && m_secretKey.getCContent() != 0)
-            out["secretKey"] = m_secretKey->asString();
+            (*out)["secretKey"] = m_secretKey->asString();
     }
     if (_order == ExportOrder::OldStyle)
     {
-        out.setKeyPos("r", 4);
-        out.setKeyPos("s", 5);
-        out.setKeyPos("v", 7);
+        (*out).setKeyPos("r", 4);
+        (*out).setKeyPos("s", 5);
+        (*out).setKeyPos("v", 7);
     }
 
     // standard transaction output without gas_price end
 
     // begin eip1559 transaction info
-    out["chainId"] = "0x01";
-    out["type"] = "0x02";
-    out["maxFeePerGas"] = m_maxFeePerGas->asString();
-    out["maxPriorityFeePerGas"] = m_maxPriorityFeePerGas->asString();
+    (*out)["chainId"] = "0x01";
+    (*out)["type"] = "0x02";
+    (*out)["maxFeePerGas"] = m_maxFeePerGas->asString();
+    (*out)["maxPriorityFeePerGas"] = m_maxPriorityFeePerGas->asString();
     if (_order == ExportOrder::ToolStyle)
     {
-        out["chainId"] = "0x1";
-        out["type"] = "0x2";
+        (*out)["chainId"] = "0x1";
+        (*out)["type"] = "0x2";
 
-        DataObject t8ntoolFields;
-        t8ntoolFields["maxFeePerGas"] = m_maxFeePerGas->asString();
-        t8ntoolFields["maxPriorityFeePerGas"] = m_maxPriorityFeePerGas->asString();
-        t8ntoolFields.performModifier(mod_removeLeadingZerosFromHexValues);
-        out["maxFeePerGas"] = t8ntoolFields["maxFeePerGas"];
-        out["maxPriorityFeePerGas"] = t8ntoolFields["maxPriorityFeePerGas"];
+        spDataObject t8ntoolFields(new DataObject());
+        (*t8ntoolFields)["maxFeePerGas"] = m_maxFeePerGas->asString();
+        (*t8ntoolFields)["maxPriorityFeePerGas"] = m_maxPriorityFeePerGas->asString();
+        (*t8ntoolFields).performModifier(mod_removeLeadingZerosFromHexValues);
+        (*out)["maxFeePerGas"] = (*t8ntoolFields)["maxFeePerGas"].asString();
+        (*out)["maxPriorityFeePerGas"] = (*t8ntoolFields)["maxPriorityFeePerGas"].asString();
 
         if (!m_secretKey.isEmpty() && m_secretKey.getCContent() != 0)
-            out["secretKey"] = m_secretKey->asString();
+            (*out)["secretKey"] = m_secretKey->asString();
     }
-    out["accessList"] = m_accessList->asDataObject();
+    (*out).atKeyPointer("accessList") = m_accessList->asDataObject();
     return out;
 }
 

--- a/retesteth/testStructures/types/Ethereum/TransactionBaseFee.h
+++ b/retesteth/testStructures/types/Ethereum/TransactionBaseFee.h
@@ -13,7 +13,7 @@ struct TransactionBaseFee : Transaction
     TransactionBaseFee(BYTES const&);
     TransactionBaseFee(dev::RLP const&);
 
-    DataObject const asDataObject(ExportOrder _order = ExportOrder::Default) const override;
+    spDataObject asDataObject(ExportOrder _order = ExportOrder::Default) const override;
     TransactionType type() const override { return TransactionType::BASEFEE; }
 
 private:

--- a/retesteth/testStructures/types/Ethereum/TransactionLegacy.cpp
+++ b/retesteth/testStructures/types/Ethereum/TransactionLegacy.cpp
@@ -153,9 +153,9 @@ void TransactionLegacy::buildVRS(VALUE const& _secret)
         sigStruct.isValid(), TestOutputHelper::get().testName() + " Could not construct transaction signature!");
 
     // 27 because devcrypto signing donesn't count chain id
-    DataObject v = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.v + 27)));
-    DataObject r = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.r)));
-    DataObject s = DataObject(dev::toCompactHexPrefixed(dev::u256(sigStruct.s)));
+    bigint v (dev::toCompactHexPrefixed(dev::u256(sigStruct.v + 27)));
+    bigint r (dev::toCompactHexPrefixed(dev::u256(sigStruct.r)));
+    bigint s (dev::toCompactHexPrefixed(dev::u256(sigStruct.s)));
     m_v = spVALUE(new VALUE(v));
     m_r = spVALUE(new VALUE(r));
     m_s = spVALUE(new VALUE(s));
@@ -163,37 +163,37 @@ void TransactionLegacy::buildVRS(VALUE const& _secret)
 }
 
 
-const DataObject TransactionLegacy::asDataObject(ExportOrder _order) const
+spDataObject TransactionLegacy::asDataObject(ExportOrder _order) const
 {
-    DataObject out;
-    out["data"] = m_data->asString();
-    out["gasLimit"] = m_gasLimit->asString();
-    out["gasPrice"] = m_gasPrice->asString();
-    out["nonce"] = m_nonce->asString();
+    spDataObject out(new DataObject());
+    (*out)["data"] = m_data->asString();
+    (*out)["gasLimit"] = m_gasLimit->asString();
+    (*out)["gasPrice"] = m_gasPrice->asString();
+    (*out)["nonce"] = m_nonce->asString();
     if (m_creation)
     {
         if (_order != ExportOrder::ToolStyle)
-            out["to"] = "";
+            (*out)["to"] = "";
     }
     else
-        out["to"] = m_to->asString();
-    out["value"] = m_value->asString();
-    out["v"] = m_v->asString();
-    out["r"] = m_r->asString();
-    out["s"] = m_s->asString();
+        (*out)["to"] = m_to->asString();
+    (*out)["value"] = m_value->asString();
+    (*out)["v"] = m_v->asString();
+    (*out)["r"] = m_r->asString();
+    (*out)["s"] = m_s->asString();
     if (_order == ExportOrder::ToolStyle)
     {
-        out.performModifier(mod_removeLeadingZerosFromHexValues, {"data", "to"});
-        out.renameKey("gasLimit", "gas");
-        out.renameKey("data", "input");
+        (*out).performModifier(mod_removeLeadingZerosFromHexValues, {"data", "to"});
+        (*out).renameKey("gasLimit", "gas");
+        (*out).renameKey("data", "input");
         if (!m_secretKey.isEmpty() && m_secretKey.getCContent() != 0)
-            out["secretKey"] = m_secretKey->asString();
+            (*out)["secretKey"] = m_secretKey->asString();
     }
     if (_order == ExportOrder::OldStyle)
     {
-        out.setKeyPos("r", 4);
-        out.setKeyPos("s", 5);
-        out.setKeyPos("v", 7);
+        (*out).setKeyPos("r", 4);
+        (*out).setKeyPos("s", 5);
+        (*out).setKeyPos("v", 7);
     }
     return out;
 }

--- a/retesteth/testStructures/types/Ethereum/TransactionLegacy.h
+++ b/retesteth/testStructures/types/Ethereum/TransactionLegacy.h
@@ -22,7 +22,7 @@ struct TransactionLegacy : Transaction
     VALUE const& gasPrice() const { return m_gasPrice; }
 
     virtual TransactionType type() const override { return TransactionType::LEGACY; }
-    virtual DataObject const asDataObject(ExportOrder _order = ExportOrder::Default) const override;
+    virtual spDataObject asDataObject(ExportOrder _order = ExportOrder::Default) const override;
 
 protected:
     TransactionLegacy() {}

--- a/retesteth/testStructures/types/RPC/DebugStorageRangeAt.cpp
+++ b/retesteth/testStructures/types/RPC/DebugStorageRangeAt.cpp
@@ -13,7 +13,7 @@ DebugStorageRangeAt::DebugStorageRangeAt(DataObject const& _data)
         // Convert to test storage representation
         DataObject storageCorrect;
         for (auto const& record : _data.atKey("storage").getSubObjects())
-            storageCorrect[record.atKey("key").asString()] = record.atKey("value").asString();
+            storageCorrect[record->atKey("key").asString()] = record->atKey("value").asString();
         m_storage = spStorage(new Storage(storageCorrect));
         if (_data.count("nextKey"))
             m_nextKey = spFH32(new FH32(_data.atKey("nextKey")));

--- a/retesteth/testStructures/types/RPC/DebugTraceTransaction.cpp
+++ b/retesteth/testStructures/types/RPC/DebugTraceTransaction.cpp
@@ -25,7 +25,10 @@ DebugTraceTransaction::DebugTraceTransaction(DataObject const& _data)
     }
 }
 
-DebugTraceTransactionLog::DebugTraceTransactionLog(DataObject const& _data) : m_data(_data) {}
+DebugTraceTransactionLog::DebugTraceTransactionLog(DataObject const& _data) {
+    m_data = spDataObject(new DataObject());
+    (*m_data).copyFrom(_data);
+}
 
 string DebugTraceTransaction::getFinal() const
 {

--- a/retesteth/testStructures/types/RPC/DebugTraceTransaction.h
+++ b/retesteth/testStructures/types/RPC/DebugTraceTransaction.h
@@ -11,11 +11,11 @@ namespace teststruct
 struct DebugTraceTransactionLog
 {
     DebugTraceTransactionLog(DataObject const&);
-    VALUE gas() const { return VALUE(m_data.atKey("gas").asString()); }
+    VALUE gas() const { return VALUE(m_data->atKey("gas")); }
     DataObject const& getData() const { return m_data; }
 
 private:
-    DataObject m_data;
+    spDataObject m_data;
 };
 
 struct DebugTraceTransaction

--- a/retesteth/testStructures/types/RPC/DebugVMTrace.cpp
+++ b/retesteth/testStructures/types/RPC/DebugVMTrace.cpp
@@ -20,8 +20,6 @@ VMLogRecord::VMLogRecord(DataObject const& _obj)
         memSize = _obj.atKey("memSize").asInt();
         for (auto const& el : _obj.atKey("stack").getSubObjects())
             stack.push_back(el->asString());
-        for (auto const& el : _obj.atKey("returnStack").getSubObjects())
-            returnStack.push_back(el->asString());
         returnData = spBYTES(new BYTES(DataObject("0x")));
         depth = _obj.atKey("depth").asInt();
         refund = _obj.atKey("refund").asInt();

--- a/retesteth/testStructures/types/RPC/DebugVMTrace.cpp
+++ b/retesteth/testStructures/types/RPC/DebugVMTrace.cpp
@@ -19,9 +19,9 @@ VMLogRecord::VMLogRecord(DataObject const& _obj)
         memory = spBYTES(new BYTES(_obj.atKey("memory")));
         memSize = _obj.atKey("memSize").asInt();
         for (auto const& el : _obj.atKey("stack").getSubObjects())
-            stack.push_back(el.asString());
+            stack.push_back(el->asString());
         for (auto const& el : _obj.atKey("returnStack").getSubObjects())
-            returnStack.push_back(el.asString());
+            returnStack.push_back(el->asString());
         returnData = spBYTES(new BYTES(DataObject("0x")));
         depth = _obj.atKey("depth").asInt();
         refund = _obj.atKey("refund").asInt();

--- a/retesteth/testStructures/types/RPC/DebugVMTrace.cpp
+++ b/retesteth/testStructures/types/RPC/DebugVMTrace.cpp
@@ -48,10 +48,10 @@ DebugVMTrace::DebugVMTrace(string const& _info, string const& _trNumber, FH32 co
             for (size_t i = 0; i < logs.size() - 1; i++)
                 m_log.push_back(VMLogRecord(ConvertJsoncppStringToData(logs.at(i))));
 
-            DataObject lastRecord(ConvertJsoncppStringToData(logs.at(logs.size() - 1)));
-            m_output = lastRecord.atKey("output").asString();
-            m_gasUsed = spVALUE(new VALUE(lastRecord.atKey("gasUsed")));
-            m_time = lastRecord.atKey("time").asInt();
+            spDataObject lastRecord = ConvertJsoncppStringToData(logs.at(logs.size() - 1));
+            m_output = lastRecord->atKey("output").asString();
+            m_gasUsed = spVALUE(new VALUE(lastRecord->atKey("gasUsed")));
+            m_time = lastRecord->atKey("time").asInt();
         }
 
         m_rawUnparsedLogs = _logs;

--- a/retesteth/testStructures/types/RPC/DebugVMTrace.h
+++ b/retesteth/testStructures/types/RPC/DebugVMTrace.h
@@ -25,7 +25,6 @@ struct VMLogRecord
     spBYTES memory;
     long long memSize;
     std::vector<string> stack;
-    std::vector<string> returnStack;
     spBYTES returnData;
     size_t depth;
     spVALUE refund;

--- a/retesteth/testStructures/types/RPC/EthGetBlockBy.cpp
+++ b/retesteth/testStructures/types/RPC/EthGetBlockBy.cpp
@@ -23,7 +23,8 @@ EthGetBlockBy::EthGetBlockBy(DataObject const& _data)
         m_lessobjects = false;
         for (auto const& el : _data.atKey("transactions").getSubObjects())
         {
-            spDataObject cel;
+            // TODO get rid of copy here
+            spDataObject cel(new DataObject());
             (*cel).copyFrom(el);
             (*cel).renameKey("input", "data");
             (*cel).renameKey("gas", "gasLimit");

--- a/retesteth/testStructures/types/RPC/EthGetBlockBy.cpp
+++ b/retesteth/testStructures/types/RPC/EthGetBlockBy.cpp
@@ -23,9 +23,10 @@ EthGetBlockBy::EthGetBlockBy(DataObject const& _data)
         m_lessobjects = false;
         for (auto const& el : _data.atKey("transactions").getSubObjects())
         {
-            DataObject cel = el;
-            cel.renameKey("input", "data");
-            cel.renameKey("gas", "gasLimit");
+            spDataObject cel;
+            (*cel).copyFrom(el);
+            (*cel).renameKey("input", "data");
+            (*cel).renameKey("gas", "gasLimit");
 
             m_transactions.push_back(EthGetBlockByTransaction(cel));
             if (!m_transactions.at(m_transactions.size() - 1).isFullTransaction())

--- a/retesteth/testStructures/types/RPC/MineBlocksResult.h
+++ b/retesteth/testStructures/types/RPC/MineBlocksResult.h
@@ -28,7 +28,7 @@ struct MineBlocksResult
             {
                 for (auto const& el : _data.atKey("rejectedTransactions").getSubObjects())
                     m_rejectedTransactions.emplace(
-                                FH32(el.atKey("hash").asString()), el.atKey("error").asString());
+                        FH32(el->atKey("hash").asString()), el->atKey("error").asString());
             }
             requireJsonFields(_data, "test_mineBlocks::MineBlocksResult",
                 {{"result", {{DataType::Bool, DataType::Integer}, jsonField::Required}},

--- a/retesteth/testStructures/types/RPC/SetChainParamsArgs.cpp
+++ b/retesteth/testStructures/types/RPC/SetChainParamsArgs.cpp
@@ -8,6 +8,7 @@ namespace teststruct
 {
 SetChainParamsArgs::SetChainParamsArgs(DataObject const& _data)
 {
+    m_params = spDataObject(new DataObject());
     (*m_params).copyFrom(_data.atKey("params"));  // Client specific params
     m_preState = spState(new State(_data.atKey("accounts")));
     m_sealEngine = sealEngineFromStr(_data.atKey("sealEngine").asString());

--- a/retesteth/testStructures/types/RPC/SetChainParamsArgs.cpp
+++ b/retesteth/testStructures/types/RPC/SetChainParamsArgs.cpp
@@ -8,23 +8,24 @@ namespace teststruct
 {
 SetChainParamsArgs::SetChainParamsArgs(DataObject const& _data)
 {
-    m_params = _data.atKey("params");  // Client specific params
+    (*m_params).copyFrom(_data.atKey("params"));  // Client specific params
     m_preState = spState(new State(_data.atKey("accounts")));
     m_sealEngine = sealEngineFromStr(_data.atKey("sealEngine").asString());
 
     // Fill up required fields for blocheader info
     DataObject const& genesis = _data.atKey("genesis");
-    DataObject fullBlockHeader;
-    fullBlockHeader["author"] = genesis.atKey("author");
-    fullBlockHeader["difficulty"] = genesis.atKey("difficulty");
-    fullBlockHeader["gasLimit"] = genesis.atKey("gasLimit");
+    spDataObject _fullBlockHeader(new DataObject());
+    DataObject& fullBlockHeader = _fullBlockHeader.getContent();
+    fullBlockHeader["author"] = genesis.atKey("author").asString();
+    fullBlockHeader["difficulty"] = genesis.atKey("difficulty").asString();
+    fullBlockHeader["gasLimit"] = genesis.atKey("gasLimit").asString();
     if (genesis.count("baseFeePerGas"))
-        fullBlockHeader["baseFeePerGas"] = genesis.atKey("baseFeePerGas");
+        fullBlockHeader["baseFeePerGas"] = genesis.atKey("baseFeePerGas").asString();
 
-    fullBlockHeader["extraData"] = genesis.atKey("extraData");
-    fullBlockHeader["timestamp"] = genesis.atKey("timestamp");
-    fullBlockHeader["nonce"] = genesis.atKey("nonce");
-    fullBlockHeader["mixHash"] = genesis.atKey("mixHash");
+    fullBlockHeader["extraData"] = genesis.atKey("extraData").asString();
+    fullBlockHeader["timestamp"] = genesis.atKey("timestamp").asString();
+    fullBlockHeader["nonce"] = genesis.atKey("nonce").asString();
+    fullBlockHeader["mixHash"] = genesis.atKey("mixHash").asString();
 
     // Fields that are ommited in RPC setChainParams, use default fields of empty block
     fullBlockHeader["bloom"] = FH256::zero().asString();
@@ -45,26 +46,26 @@ SetChainParamsArgs::SetChainParamsArgs(DataObject const& _data)
          {"sealEngine", {{DataType::String}, jsonField::Required}}});
 }
 
-DataObject SetChainParamsArgs::asDataObject() const
+spDataObject SetChainParamsArgs::asDataObject() const
 {
     spDataObject out (new DataObject());
-    out["params"] = m_params;
-    out["accounts"] = m_preState->asDataObject();
-    out["sealEngine"] = sealEngineToStr(m_sealEngine);
-    out["genesis"]["author"] = m_genesis->author().asString();
-    out["genesis"]["difficulty"] = m_genesis->difficulty().asString();
-    out["genesis"]["gasLimit"] = m_genesis->gasLimit().asString();
+    (*out)["params"].copyFrom(m_params);
+    (*out).atKeyPointer("accounts") = m_preState->asDataObject();
+    (*out)["sealEngine"] = sealEngineToStr(m_sealEngine);
+    (*out)["genesis"]["author"] = m_genesis->author().asString();
+    (*out)["genesis"]["difficulty"] = m_genesis->difficulty().asString();
+    (*out)["genesis"]["gasLimit"] = m_genesis->gasLimit().asString();
 
     if (m_genesis->type() == BlockType::BlockHeader1559)
     {
         BlockHeader1559 const& newbl = BlockHeader1559::castFrom(m_genesis);
-        out["genesis"]["baseFeePerGas"] = newbl.baseFee().asString();
+        (*out)["genesis"]["baseFeePerGas"] = newbl.baseFee().asString();
     }
 
-    out["genesis"]["extraData"] = m_genesis->extraData().asString();
-    out["genesis"]["timestamp"] = m_genesis->timestamp().asString();
-    out["genesis"]["nonce"] = m_genesis->nonce().asString();
-    out["genesis"]["mixHash"] = m_genesis->mixHash().asString();
+    (*out)["genesis"]["extraData"] = m_genesis->extraData().asString();
+    (*out)["genesis"]["timestamp"] = m_genesis->timestamp().asString();
+    (*out)["genesis"]["nonce"] = m_genesis->nonce().asString();
+    (*out)["genesis"]["mixHash"] = m_genesis->mixHash().asString();
     return out;
 }
 

--- a/retesteth/testStructures/types/RPC/SetChainParamsArgs.cpp
+++ b/retesteth/testStructures/types/RPC/SetChainParamsArgs.cpp
@@ -47,7 +47,7 @@ SetChainParamsArgs::SetChainParamsArgs(DataObject const& _data)
 
 DataObject SetChainParamsArgs::asDataObject() const
 {
-    DataObject out;
+    spDataObject out (new DataObject());
     out["params"] = m_params;
     out["accounts"] = m_preState->asDataObject();
     out["sealEngine"] = sealEngineToStr(m_sealEngine);

--- a/retesteth/testStructures/types/RPC/SetChainParamsArgs.h
+++ b/retesteth/testStructures/types/RPC/SetChainParamsArgs.h
@@ -26,7 +26,7 @@ protected:
     spState m_preState;
     SealEngine m_sealEngine;
     spBlockHeader m_genesis;
-    DataObject m_params;
+    spDataObject m_params;
 };
 
 }  // namespace teststruct

--- a/retesteth/testStructures/types/RPC/SetChainParamsArgs.h
+++ b/retesteth/testStructures/types/RPC/SetChainParamsArgs.h
@@ -15,7 +15,7 @@ struct SetChainParamsArgs : GCP_SPointerBase
     SetChainParamsArgs(DataObject const& _data);
     SetChainParamsArgs* copy() const { return new SetChainParamsArgs(asDataObject()); }
 
-    DataObject asDataObject() const;
+    spDataObject asDataObject() const;
     spBlockHeader const& genesis() const { return m_genesis; }
     State const& state() const { return m_preState; }
     SealEngine sealEngine() const { return m_sealEngine; }

--- a/retesteth/testStructures/types/StateTests/Base/AccessList.cpp
+++ b/retesteth/testStructures/types/StateTests/Base/AccessList.cpp
@@ -22,18 +22,21 @@ AccessList::AccessList(DataObject const& _data)
         m_list.push_back(spAccessListElement(new AccessListElement(el)));
 }
 
-DataObject AccessList::asDataObject() const
+spDataObject AccessList::asDataObject() const
 {
-    DataObject accessList(DataType::Array);
+    spDataObject accessList(new DataObject(DataType::Array));
     for (auto const& el : m_list)
     {
-        DataObject accessListElement;
-        accessListElement["address"] = el->address().asString();
-        DataObject keys(DataType::Array);
+        spDataObject accessListElement(new DataObject());
+        (*accessListElement)["address"] = el->address().asString();
+        spDataObject keys(new DataObject(DataType::Array));
+        (*accessListElement)["storageKeys"].copyFrom(keys);
         for (auto const& el2 : el->keys())
-            keys.addArrayObject(el2->asString());
-        accessListElement["storageKeys"] = keys;
-        accessList.addArrayObject(accessListElement);
+        {
+            spDataObject k(new DataObject(el2->asString()));
+            (*accessListElement)["storageKeys"].addArrayObject(k);
+        }
+        (*accessList).addArrayObject(accessListElement);
     }
     return accessList;
 }

--- a/retesteth/testStructures/types/StateTests/Base/AccessList.cpp
+++ b/retesteth/testStructures/types/StateTests/Base/AccessList.cpp
@@ -13,7 +13,8 @@ AccessListElement::AccessListElement(DataObject const& _data)
         m_storageKeys.push_back(spFH32(new FH32(dev::toCompactHexPrefixed(dev::u256(el->asString()), 32))));
 
     requireJsonFields(_data, "AccessListElement " + _data.getKey(),
-        {{"address", {{DataType::String}, jsonField::Required}}, {"storageKeys", {{DataType::Array}, jsonField::Required}}});
+        {{"address", {{DataType::String}, jsonField::Required}},
+         {"storageKeys", {{DataType::Array}, jsonField::Required}}});
 }
 
 AccessList::AccessList(DataObject const& _data)
@@ -30,7 +31,7 @@ spDataObject AccessList::asDataObject() const
         spDataObject accessListElement(new DataObject());
         (*accessListElement)["address"] = el->address().asString();
         spDataObject keys(new DataObject(DataType::Array));
-        (*accessListElement)["storageKeys"].copyFrom(keys);
+        (*accessListElement).atKeyPointer("storageKeys") = keys;
         for (auto const& el2 : el->keys())
         {
             spDataObject k(new DataObject(el2->asString()));

--- a/retesteth/testStructures/types/StateTests/Base/AccessList.cpp
+++ b/retesteth/testStructures/types/StateTests/Base/AccessList.cpp
@@ -10,7 +10,7 @@ AccessListElement::AccessListElement(DataObject const& _data)
 {
     m_address = spFH20(new FH20(_data.atKey("address")));
     for (auto const& el : _data.atKey("storageKeys").getSubObjects())
-        m_storageKeys.push_back(spFH32(new FH32(dev::toCompactHexPrefixed(dev::u256(el.asString()), 32))));
+        m_storageKeys.push_back(spFH32(new FH32(dev::toCompactHexPrefixed(dev::u256(el->asString()), 32))));
 
     requireJsonFields(_data, "AccessListElement " + _data.getKey(),
         {{"address", {{DataType::String}, jsonField::Required}}, {"storageKeys", {{DataType::Array}, jsonField::Required}}});

--- a/retesteth/testStructures/types/StateTests/Base/AccessList.h
+++ b/retesteth/testStructures/types/StateTests/Base/AccessList.h
@@ -28,7 +28,7 @@ struct AccessList : GCP_SPointerBase
     AccessList(){};
     AccessList(DataObject const&);
     AccessList(dev::RLP const& _rlp);
-    DataObject asDataObject() const;
+    spDataObject asDataObject() const;
     std::vector<spAccessListElement> const& list() const { return m_list; }
 
 private:

--- a/retesteth/testStructures/types/StateTests/Base/StateTestEnvBase.cpp
+++ b/retesteth/testStructures/types/StateTests/Base/StateTestEnvBase.cpp
@@ -5,20 +5,20 @@ namespace test
 namespace teststruct
 {
 // Export Env Function Some formatters might be performed here
-const DataObject StateTestEnvBase::asDataObject() const
+spDataObject StateTestEnvBase::asDataObject() const
 {
-    DataObject out;
-    out["currentCoinbase"] = m_currentCoinbase->asString();
-    out["currentDifficulty"] = m_currentDifficulty->asString();
-    out["currentNumber"] = m_currentNumber->asString();
-    out["currentTimestamp"] = m_currentTimestamp->asString();
-    out["previousHash"] = m_previousHash->asString();
-    out["currentGasLimit"] = m_currentGasLimit->asString();
+    spDataObject out(new DataObject());
+    (*out)["currentCoinbase"] = m_currentCoinbase->asString();
+    (*out)["currentDifficulty"] = m_currentDifficulty->asString();
+    (*out)["currentNumber"] = m_currentNumber->asString();
+    (*out)["currentTimestamp"] = m_currentTimestamp->asString();
+    (*out)["previousHash"] = m_previousHash->asString();
+    (*out)["currentGasLimit"] = m_currentGasLimit->asString();
 
     if (!m_currentBaseFee.isEmpty())
     {
         // EIP1559 env info
-        out["currentBaseFee"] = m_currentBaseFee->asString();
+        (*out)["currentBaseFee"] = m_currentBaseFee->asString();
     }
     return out;
 }

--- a/retesteth/testStructures/types/StateTests/Base/StateTestEnvBase.h
+++ b/retesteth/testStructures/types/StateTests/Base/StateTestEnvBase.h
@@ -25,7 +25,7 @@ struct StateTestEnvBase : GCP_SPointerBase
     FH8 const& currentNonce() const { return m_currentNonce; }
     FH32 const& currentMixHash() const { return m_currentMixHash; }
     FH32 const& previousHash() const { return m_previousHash; }
-    DataObject const asDataObject() const;
+    spDataObject asDataObject() const;
 
     spVALUE const& currentBaseFee() const { return m_currentBaseFee; }
 

--- a/retesteth/testStructures/types/StateTests/Base/StateTestTransactionBase.h
+++ b/retesteth/testStructures/types/StateTests/Base/StateTestTransactionBase.h
@@ -14,7 +14,7 @@ namespace teststruct
 // Base logic for State Test Transaction section
 struct StateTestTransactionBase : GCP_SPointerBase
 {
-    DataObject const asDataObject() const;
+    spDataObject asDataObject() const;
     std::vector<TransactionInGeneralSection> buildTransactions() const;
 
     struct Databox

--- a/retesteth/testStructures/types/StateTests/Filled/Info.cpp
+++ b/retesteth/testStructures/types/StateTests/Filled/Info.cpp
@@ -17,7 +17,7 @@ Info::Info(DataObject const& _data)
     if (_data.count("labels"))
     {
         for (auto const& el : _data.atKey("labels").getSubObjects())
-            m_labels.emplace(el.getKey(), el.asString());
+            m_labels.emplace(el->getKey(), el->asString());
     }
 
     requireJsonFields(_data, "Info " + _data.getKey(),

--- a/retesteth/testStructures/types/StateTests/Filled/StateTestPostResult.cpp
+++ b/retesteth/testStructures/types/StateTests/Filled/StateTestPostResult.cpp
@@ -25,15 +25,15 @@ StateTestPostResult::StateTestPostResult(DataObject const& _data)
          {"logs", {{DataType::String}, jsonField::Optional}}});
 }
 
-const DataObject StateTestPostResult::asDataObject() const
+spDataObject StateTestPostResult::asDataObject() const
 {
-    DataObject res;
-    res["hash"] = m_hash->asString();
+    spDataObject res (new DataObject());
+    (*res)["hash"] = m_hash->asString();
     if (!m_log.isEmpty())
-        res["logs"] = m_log->asString();
-    res["indexes"]["data"] = m_dataInd;
-    res["indexes"]["gas"] = m_gasInd;
-    res["indexes"]["value"] = m_valInd;
+        (*res)["logs"] = m_log->asString();
+    (*res)["indexes"]["data"] = m_dataInd;
+    (*res)["indexes"]["gas"] = m_gasInd;
+    (*res)["indexes"]["value"] = m_valInd;
     return res;
 }
 

--- a/retesteth/testStructures/types/StateTests/Filled/StateTestPostResult.h
+++ b/retesteth/testStructures/types/StateTests/Filled/StateTestPostResult.h
@@ -25,7 +25,7 @@ struct StateTestPostResult : GCP_SPointerBase
         return m_log;
     }
     spBYTES const& bytesPtr() const { return m_txbytes; }
-    DataObject const asDataObject() const;
+    spDataObject asDataObject() const;
     string const& expectException() const { return m_expectException; }
 
 private:

--- a/retesteth/testStructures/types/StateTests/Filled/StateTestTransaction.cpp
+++ b/retesteth/testStructures/types/StateTests/Filled/StateTestTransaction.cpp
@@ -39,7 +39,7 @@ StateTestTransaction::StateTestTransaction(DataObject const& _data)
 
         for (auto const& el : _data.atKey("data").getSubObjects())
         {
-            DataObject dataInKey = el.getCContent();
+            DataObject const& dataInKey = el.getCContent();
             string const sDataPreview = el->asString().substr(0, 8);
             if (accessLists.size())
             {

--- a/retesteth/testStructures/types/StateTests/Filled/StateTestTransaction.cpp
+++ b/retesteth/testStructures/types/StateTests/Filled/StateTestTransaction.cpp
@@ -25,7 +25,7 @@ StateTestTransaction::StateTestTransaction(DataObject const& _data)
         {
             for (auto const& el : _data.atKey("accessLists").getSubObjects())
             {
-                if (el.type() == DataType::Null)
+                if (el->type() == DataType::Null)
                     accessLists.push_back(spAccessList(0));
                 else
                     accessLists.push_back(spAccessList(new AccessList(el)));
@@ -39,8 +39,8 @@ StateTestTransaction::StateTestTransaction(DataObject const& _data)
 
         for (auto const& el : _data.atKey("data").getSubObjects())
         {
-            DataObject dataInKey = el;
-            string const sDataPreview = el.asString().substr(0, 8);
+            DataObject dataInKey = el.getCContent();
+            string const sDataPreview = el->asString().substr(0, 8);
             if (accessLists.size())
             {
                 if (accessLists.at(index).isEmpty())
@@ -54,9 +54,9 @@ StateTestTransaction::StateTestTransaction(DataObject const& _data)
             index++;
         }
         for (auto const& el : _data.atKey("gasLimit").getSubObjects())
-            m_gasLimit.push_back(el);
+            m_gasLimit.push_back(el.getCContent());
         for (auto const& el : _data.atKey("value").getSubObjects())
-            m_value.push_back(el);
+            m_value.push_back(el.getCContent());
 
         if (_data.count("maxFeePerGas") || _data.count("maxPriorityFeePerGas"))
         {

--- a/retesteth/testStructures/types/StateTests/Filler/StateTestFillerEnv.cpp
+++ b/retesteth/testStructures/types/StateTests/Filler/StateTestFillerEnv.cpp
@@ -10,39 +10,41 @@ StateTestFillerEnv::StateTestFillerEnv(DataObject const& _data)
 {
     try
     {
-        DataObject tmpData = _data;
-        tmpData.removeKey("currentCoinbase");
-        tmpData.performModifier(mod_valueToCompactEvenHexPrefixed);
+        spDataObject tmpData(new DataObject());
+        (*tmpData).copyFrom(_data);
+        (*tmpData).removeKey("currentCoinbase");
+        (*tmpData).performModifier(mod_valueToCompactEvenHexPrefixed);
 
-        DataObject coinbase = _data.atKey("currentCoinbase");
-        if (coinbase.asString().size() > 1 && coinbase.asString()[1] != 'x')
-            coinbase = "0x" + coinbase.asString();
+        spDataObject coinbase(new DataObject());
+        (*coinbase).copyFrom(_data.atKey("currentCoinbase"));
+        if (coinbase->asString().size() > 1 && coinbase->asString()[1] != 'x')
+            (*coinbase) = "0x" + coinbase->asString();
         m_currentCoinbase = spFH20(new FH20(coinbase));
 
-        m_currentDifficulty = spVALUE(new VALUE(tmpData.atKey("currentDifficulty")));
-        m_currentNumber = spVALUE(new VALUE(tmpData.atKey("currentNumber")));
+        m_currentDifficulty = spVALUE(new VALUE(tmpData->atKey("currentDifficulty")));
+        m_currentNumber = spVALUE(new VALUE(tmpData->atKey("currentNumber")));
 
         // Indicates first block timestamp in StateTests
-        m_currentTimestamp = spVALUE(new VALUE(tmpData.atKey("currentTimestamp")));
+        m_currentTimestamp = spVALUE(new VALUE(tmpData->atKey("currentTimestamp")));
         // Indicates zero block timestamp in StateTests
         m_genesisTimestamp = spVALUE(new VALUE(0));
 
         // Do not allow hash without 0x
-        m_previousHash = spFH32(new FH32(tmpData.atKey("previousHash")));
+        m_previousHash = spFH32(new FH32(tmpData->atKey("previousHash")));
 
-        DataObject tmpD;
-        tmpD = "0x00";  // State Tests extra data is 0x00
+        spDataObject tmpD(new DataObject());
+        (*tmpD) = "0x00";  // State Tests extra data is 0x00
         m_currentExtraData = spBYTES(new BYTES(tmpD));
         m_currentNonce = spFH8(new FH8(FH8::zero()));
         m_currentMixHash = spFH32(new FH32(FH32::zero()));
-        m_currentGasLimit = spVALUE(new VALUE(tmpData.atKey("currentGasLimit")));
+        m_currentGasLimit = spVALUE(new VALUE(tmpData->atKey("currentGasLimit")));
         if (m_currentGasLimit.getCContent() > dev::bigint("0x7fffffffffffffff"))
             throw test::UpwardsException("currentGasLimit > 0x7fffffffffffffff");
 
         if (_data.count("currentBaseFee"))
         {
             // 1559 env info
-            m_currentBaseFee = spVALUE(new VALUE(tmpData.atKey("currentBaseFee")));
+            m_currentBaseFee = spVALUE(new VALUE(tmpData->atKey("currentBaseFee")));
             requireJsonFields(_data, "StateTestFillerEnv " + _data.getKey(),
                 {{"currentCoinbase", {{DataType::String}, jsonField::Required}},
                 {"currentDifficulty", {{DataType::String}, jsonField::Required}},

--- a/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.cpp
+++ b/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.cpp
@@ -9,7 +9,7 @@ namespace teststruct
 {
 // Look at expect section data indexes filter and try to replace string values
 // into indexes of transaction data array (searching by label)
-DataObject ReplaceValueToIndexesInDataList(spStateTestFillerTransaction const& _gtr, DataObject const& _dataList)
+spDataObject ReplaceValueToIndexesInDataList(spStateTestFillerTransaction const& _gtr, DataObject const& _dataList)
 {
     auto findIndexOfValueAndReplace = [&_gtr](DataObject& _data) {
         if (_data.type() == DataType::String)
@@ -41,39 +41,41 @@ DataObject ReplaceValueToIndexesInDataList(spStateTestFillerTransaction const& _
     };
     // Check if dataIndexes contain values of transaction data vector
     // Find those values and vector and replace by indexes
-    DataObject dataIndexes = _dataList;
-    if (dataIndexes.type() == DataType::Array)
+    spDataObject dataIndexes(new DataObject());
+    (*dataIndexes).copyFrom(_dataList);
+    if (dataIndexes->type() == DataType::Array)
     {
-        DataObject updatedDataIndexes;
-        for (auto& el : dataIndexes.getSubObjectsUnsafe())
+        spDataObject updatedDataIndexes(new DataObject());
+        for (auto& el : (*dataIndexes).getSubObjectsUnsafe())
         {
             // try to replace `el` with data indexes from transaction
             // in case `el` provided is a transaction value in dataInd array
             if (el->type() == DataType::String)
             {
-                DataObject elCopy = el;
-                findIndexOfValueAndReplace(elCopy);
-                if (elCopy.type() == DataType::Integer)
+                spDataObject elCopy(new DataObject());
+                (*elCopy).copyFrom(el);
+                findIndexOfValueAndReplace(elCopy.getContent());
+                if (elCopy->type() == DataType::Integer)
                 {
                     el.getContent().replace(elCopy);
-                    updatedDataIndexes.addArrayObject(el);
+                    (*updatedDataIndexes).addArrayObject(elCopy);
                 }
-                else if (elCopy.type() == DataType::Array)
+                else if (elCopy->type() == DataType::Array)
                 {
-                    for (auto const& el2 : elCopy.getSubObjects())
-                        updatedDataIndexes.addArrayObject(el2);
+                    for (auto const& el2 : elCopy->getSubObjects())
+                        (*updatedDataIndexes).addArrayObject(el2);
                 }
                 else
-                    updatedDataIndexes.addArrayObject(el);
+                    (*updatedDataIndexes).addArrayObject(el);
             }
             else
-                updatedDataIndexes.addArrayObject(el);
+                (*updatedDataIndexes).addArrayObject(el);
         }
         dataIndexes = updatedDataIndexes;
     }
-    else if (dataIndexes.type() == DataType::String)
-        findIndexOfValueAndReplace(dataIndexes);
-    dataIndexes.setKey(_dataList.getKey());
+    else if (dataIndexes->type() == DataType::String)
+        findIndexOfValueAndReplace(dataIndexes.getContent());
+    (*dataIndexes).setKey(_dataList.getKey());
     return dataIndexes;
 }
 
@@ -81,9 +83,11 @@ StateTestFillerExpectSection::StateTestFillerExpectSection(DataObject const& _da
 {
     try
     {
-        m_initialData["indexes"] = _data.atKey("indexes");
-        m_initialData["network"] = _data.atKey("network");
-        DataObject dataIndexes = ReplaceValueToIndexesInDataList(_gtr, _data.atKey("indexes").atKey("data"));
+        m_initialData = spDataObject(new DataObject());
+        (*m_initialData).atKeyPointer("indexes").getContent().copyFrom(_data.atKey("indexes"));
+        (*m_initialData).atKeyPointer("network").getContent().copyFrom(_data.atKey("network"));
+
+        spDataObject dataIndexes = ReplaceValueToIndexesInDataList(_gtr, _data.atKey("indexes").atKey("data"));
         parseJsonIntValueIntoSet(dataIndexes, m_dataInd);
         parseJsonIntValueIntoSet(_data.atKey("indexes").atKey("gas"), m_gasInd);
         parseJsonIntValueIntoSet(_data.atKey("indexes").atKey("value"), m_valInd);

--- a/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.cpp
+++ b/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.cpp
@@ -33,7 +33,7 @@ spDataObject ReplaceValueToIndexesInDataList(spStateTestFillerTransaction const&
             {
                 _data.clear();
                 for (auto const& el : indexes)
-                    _data.addArrayObject(el);
+                    _data.addArrayObject(spDataObject(new DataObject(el)));
             }
             if (indexes.size() == 0 && _data.asString().find(":label") != string::npos)
                 ETH_ERROR_MESSAGE("Label not found in tx data: `" + _data.asString() + "`");

--- a/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.cpp
+++ b/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.cpp
@@ -49,13 +49,13 @@ DataObject ReplaceValueToIndexesInDataList(spStateTestFillerTransaction const& _
         {
             // try to replace `el` with data indexes from transaction
             // in case `el` provided is a transaction value in dataInd array
-            if (el.type() == DataType::String)
+            if (el->type() == DataType::String)
             {
                 DataObject elCopy = el;
                 findIndexOfValueAndReplace(elCopy);
                 if (elCopy.type() == DataType::Integer)
                 {
-                    el = elCopy;
+                    el.getContent().replace(elCopy);
                     updatedDataIndexes.addArrayObject(el);
                 }
                 else if (elCopy.type() == DataType::Array)

--- a/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.h
+++ b/retesteth/testStructures/types/StateTests/Filler/StateTestFillerExpectSection.h
@@ -44,7 +44,7 @@ private:
     std::set<int> m_valInd;
     std::vector<FORK> m_forks;
     GCP_SPointer<StateIncomplete> m_result;
-    DataObject m_initialData;
+    spDataObject m_initialData;
 
     std::map<FORK, string> m_expectExceptions;
 };

--- a/retesteth/testStructures/types/StateTests/Filler/StateTestFillerTransaction.cpp
+++ b/retesteth/testStructures/types/StateTests/Filler/StateTestFillerTransaction.cpp
@@ -32,8 +32,9 @@ StateTestFillerTransaction::StateTestFillerTransaction(DataObject const& _data)
         m_secretKey = spFH32(new FH32(tmpD.atKey("secretKey")));
         m_nonce = spVALUE(new VALUE(tmpD.atKey("nonce")));
 
-        for (auto const& el : _data.atKey("data").getSubObjects())
+        for (auto const& el2 : _data.atKey("data").getSubObjects())
         {
+            DataObject const& el = el2.getCContent();
             DataObject dataInKey;
             spAccessList accessList;
             if (el.type() == DataType::Object)
@@ -73,9 +74,9 @@ StateTestFillerTransaction::StateTestFillerTransaction(DataObject const& _data)
             m_databox.push_back(Databox(dataInKey, label, rawData.substr(0, 20), accessList));
         }
         for (auto const& el : tmpD.atKey("gasLimit").getSubObjects())
-            m_gasLimit.push_back(el);
+            m_gasLimit.push_back(el.getCContent());
         for (auto const& el : tmpD.atKey("value").getSubObjects())
-            m_value.push_back(el);
+            m_value.push_back(el.getCContent());
 
         if (tmpD.count("maxFeePerGas") || tmpD.count("maxPriorityFeePerGas"))
         {

--- a/retesteth/testStructures/types/StateTests/GeneralStateTest.cpp
+++ b/retesteth/testStructures/types/StateTests/GeneralStateTest.cpp
@@ -30,7 +30,9 @@ StateTestInFilled::StateTestInFilled(DataObject const& _data)
     m_env = GCP_SPointer<StateTestEnv>(new StateTestEnv(_data.atKey("env")));
 
     // -- Some tests has storage keys/values with leading zeros. Convert it to hex value
-    DataObject tmpD = _data.atKey("pre");
+    spDataObject _tmpD(new DataObject());
+    (*_tmpD).copyFrom(_data.atKey("pre"));
+    DataObject& tmpD = _tmpD.getContent();
     for (auto& acc2 : tmpD.getSubObjectsUnsafe())
     {
         DataObject& acc = acc2.getContent();

--- a/retesteth/testStructures/types/StateTests/GeneralStateTest.cpp
+++ b/retesteth/testStructures/types/StateTests/GeneralStateTest.cpp
@@ -14,7 +14,7 @@ GeneralStateTest::GeneralStateTest(DataObject const& _data)
             TestOutputHelper::get().get().testFile().string() + " A test file must contain exactly one test!");
         for (auto const& el : _data.getSubObjects())
         {
-            TestOutputHelper::get().setCurrentTestInfo(TestInfo("GeneralStateTest", el.getKey()));
+            TestOutputHelper::get().setCurrentTestInfo(TestInfo("GeneralStateTest", el->getKey()));
             m_tests.push_back(StateTestInFilled(el));
         }
     }
@@ -31,12 +31,13 @@ StateTestInFilled::StateTestInFilled(DataObject const& _data)
 
     // -- Some tests has storage keys/values with leading zeros. Convert it to hex value
     DataObject tmpD = _data.atKey("pre");
-    for (auto& acc : tmpD.getSubObjectsUnsafe())
+    for (auto& acc2 : tmpD.getSubObjectsUnsafe())
     {
+        DataObject& acc = acc2.getContent();
         for (auto& rec : acc["storage"].getSubObjectsUnsafe())
         {
-            rec.performModifier(mod_keyToCompactEvenHexPrefixed);
-            rec.performModifier(mod_valueToCompactEvenHexPrefixed);
+            rec.getContent().performModifier(mod_keyToCompactEvenHexPrefixed);
+            rec.getContent().performModifier(mod_valueToCompactEvenHexPrefixed);
         }
     }
     // -- REMOVE THIS, FIX THE TESTS
@@ -46,11 +47,11 @@ StateTestInFilled::StateTestInFilled(DataObject const& _data)
     for (auto const& elFork : _data.atKey("post").getSubObjects())
     {
         StateTestPostResults res;
-        for (auto const& elForkResults : elFork.getSubObjects())
+        for (auto const& elForkResults : elFork->getSubObjects())
             res.push_back(StateTestPostResult(elForkResults));
-        if (m_post.count(FORK(elFork.getKey())))
+        if (m_post.count(FORK(elFork->getKey())))
             ETH_ERROR_MESSAGE("StateTest post section has multiple results for the same fork!");
-        m_post[FORK(elFork.getKey())] = res;
+        m_post[FORK(elFork->getKey())] = res;
     }
     m_name = _data.getKey();
 

--- a/retesteth/testStructures/types/StateTests/GeneralStateTestFiller.cpp
+++ b/retesteth/testStructures/types/StateTests/GeneralStateTestFiller.cpp
@@ -14,7 +14,7 @@ GeneralStateTestFiller::GeneralStateTestFiller(DataObject const& _data)
             TestOutputHelper::get().get().testFile().string() + " A test file must contain exactly one test!");
         for (auto const& el : _data.getSubObjects())
         {
-            TestOutputHelper::get().setCurrentTestInfo(TestInfo("GeneralStateTestFiller", el.getKey()));
+            TestOutputHelper::get().setCurrentTestInfo(TestInfo("GeneralStateTestFiller", el->getKey()));
             m_tests.push_back(StateTestInFiller(el));
         }
     }

--- a/retesteth/testStructures/types/VMTests/VMTestFiller.cpp
+++ b/retesteth/testStructures/types/VMTests/VMTestFiller.cpp
@@ -38,7 +38,7 @@ VMTestFiller::VMTestFiller(DataObject const& _data)
             TestOutputHelper::get().get().testFile().string() + " A test file must contain exactly one test!");
         for (auto const& el : _data.getSubObjects())
         {
-            TestOutputHelper::get().setCurrentTestInfo(TestInfo("VMTestFiller", el.getKey()));
+            TestOutputHelper::get().setCurrentTestInfo(TestInfo("VMTestFiller", el->getKey()));
             m_tests.push_back(VMTestInFiller(el));
         }
     }

--- a/retesteth/testStructures/types/VMTests/VMTestFiller.cpp
+++ b/retesteth/testStructures/types/VMTests/VMTestFiller.cpp
@@ -6,9 +6,10 @@
 
 using namespace test::teststruct;
 namespace  {
-    DataObject translateExecToTransaction(DataObject const& _exec)
+    spDataObject translateExecToTransaction(DataObject const& _exec)
     {
-        DataObject gtransaction;
+        spDataObject _gtransaction(new DataObject());
+        DataObject& gtransaction = _gtransaction.getContent();
         requireJsonFields(_exec, "vmTestFiller exec",
             {{"address", {{DataType::String}, jsonField::Required}},
                 {"caller", {{DataType::String}, jsonField::Required}},
@@ -18,14 +19,14 @@ namespace  {
                 {"gasPrice", {{DataType::String}, jsonField::Required}},
                 {"origin", {{DataType::String}, jsonField::Required}},
                 {"value", {{DataType::String}, jsonField::Required}}});
-        gtransaction["data"].addArrayObject(DataObject(_exec.atKey("data").asString()));
-        gtransaction["gasLimit"].addArrayObject(DataObject(_exec.atKey("gas").asString()));
-        gtransaction["gasPrice"] = _exec.atKey("gasPrice");
+        gtransaction["data"].addArrayObject(spDataObject(new DataObject(_exec.atKey("data").asString())));
+        gtransaction["gasLimit"].addArrayObject(spDataObject(new DataObject(_exec.atKey("gas").asString())));
+        gtransaction["gasPrice"] = _exec.atKey("gasPrice").asString();
         gtransaction["nonce"] = "0";
         gtransaction["secretKey"] = "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";
-        gtransaction["to"] = _exec.atKey("address");
-        gtransaction["value"].addArrayObject(DataObject(_exec.atKey("value").asString()));
-        return gtransaction;
+        gtransaction["to"] = _exec.atKey("address").asString();
+        gtransaction["value"].addArrayObject(spDataObject(new DataObject(_exec.atKey("value").asString())));
+        return _gtransaction;
     }
 }
 VMTestFiller::VMTestFiller(DataObject const& _data)

--- a/retesteth/testSuites/Common.cpp
+++ b/retesteth/testSuites/Common.cpp
@@ -84,9 +84,11 @@ void compareTransactionException(spTransaction const& _tr, MineBlocksResult cons
     FH32 const& trHash = _tr->hash();
     string const remoteException = _mRes.getTrException(trHash);
     if (!_testException.empty() && remoteException.empty())
-        ETH_ERROR_MESSAGE("Client didn't reject transaction: (" + trHash.asString() + ") \n" + _tr->getRawBytes().asString());
+        ETH_ERROR_MESSAGE("Client didn't reject transaction: (" + trHash.asString() + ") \n" + _tr->getRawBytes().asString() +
+            "\nTest Expected: " + _testException);
     if (_testException.empty() && !remoteException.empty())
-        ETH_ERROR_MESSAGE("Client reject transaction expected to be valid: (" + trHash.asString() + ") \n" + _tr->getRawBytes().asString());
+        ETH_ERROR_MESSAGE("Client reject transaction expected to be valid: (" + trHash.asString() + ") \n" + _tr->getRawBytes().asString() +
+                          "\nReason: " + remoteException);
 
     if (!_testException.empty() && !remoteException.empty())
     {

--- a/retesteth/testSuites/Common.cpp
+++ b/retesteth/testSuites/Common.cpp
@@ -21,7 +21,7 @@ void checkAtLeastOneTest(DataObject const& _input)
     for (auto const& test : _input.getSubObjects())
     {
         ETH_ERROR_REQUIRE_MESSAGE(
-            test.type() == DataType::Object, TestOutputHelper::get().testFile().string() +
+            test->type() == DataType::Object, TestOutputHelper::get().testFile().string() +
                                                  " should contain an object under a test name.");
     }
 }
@@ -31,7 +31,7 @@ void checkOnlyOneTest(DataObject const& _input)
     ETH_ERROR_REQUIRE_MESSAGE(_input.getSubObjects().size() == 1,
         " A test file must contain only one test: " + TestOutputHelper::get().testFile().string());
 
-    ETH_ERROR_REQUIRE_MESSAGE(_input.getSubObjects().at(0).type() == DataType::Object,
+    ETH_ERROR_REQUIRE_MESSAGE(_input.getSubObjects().at(0)->type() == DataType::Object,
         TestOutputHelper::get().testFile().string() +
             " should contain an object under a test name.");
 }
@@ -50,10 +50,10 @@ void checkTestNameIsEqualToFileName(string const& _testName)
 void checkTestNameIsEqualToFileName(DataObject const& _input)
 {
     if (!TestOutputHelper::get().testFile().empty())
-        ETH_ERROR_REQUIRE_MESSAGE(_input.getSubObjects().at(0).getKey() + "Filler" ==
+        ETH_ERROR_REQUIRE_MESSAGE(_input.getSubObjects().at(0)->getKey() + "Filler" ==
                                       TestOutputHelper::get().testFile().stem().string(),
             TestOutputHelper::get().testFile().string() +
-                " contains a test with a different name '" + _input.getSubObjects().at(0).getKey() +
+                " contains a test with a different name '" + _input.getSubObjects().at(0)->getKey() +
                 "'");
 }
 

--- a/retesteth/testSuites/Common.cpp
+++ b/retesteth/testSuites/Common.cpp
@@ -93,7 +93,7 @@ void compareTransactionException(spTransaction const& _tr, MineBlocksResult cons
         string const& expectedReason = Options::getCurrentConfig().translateException(_testException);
         if (remoteException.find(expectedReason) == string::npos)
         {
-            ETH_WARNING(_tr->asDataObject().asJson());
+            ETH_WARNING(_tr->asDataObject()->asJson());
             ETH_ERROR_MESSAGE(string("Transaction rejecetd but due to a different reason: \n") +
                "Expected reason: `" + expectedReason + "` (" + _testException + ")\n" +
                "Client reason: `" + remoteException

--- a/retesteth/testSuites/CompareStates.cpp
+++ b/retesteth/testSuites/CompareStates.cpp
@@ -250,7 +250,7 @@ void compareStates(StateBase const& _stateExpect, State const& _statePost)
             result = accountCompareResult;
     }
     if (Options::get().poststate)
-        ETH_STDOUT_MESSAGE("State Dump: \n" + _statePost.asDataObject().asJson());
+        ETH_STDOUT_MESSAGE("State Dump: \n" + _statePost.asDataObject()->asJson());
     if (result != CompareResult::Success)
         ETH_ERROR_MESSAGE("CompareStates failed with errors: " + CompareResultToString(result));
 }

--- a/retesteth/testSuites/RPCTests.cpp
+++ b/retesteth/testSuites/RPCTests.cpp
@@ -36,11 +36,11 @@ using namespace test;
 
 namespace test
 {
-DataObject RPCTestSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
+spDataObject RPCTestSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
 {
     (void)_input;
     (void)_opt;
-    return DataObject();
+    return spDataObject(new DataObject());
 }
 
 TestSuite::TestPath RPCTestSuite::suiteFolder() const

--- a/retesteth/testSuites/RPCTests.h
+++ b/retesteth/testSuites/RPCTests.h
@@ -28,7 +28,7 @@ namespace test
 class RPCTestSuite : public TestSuite
 {
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestPath suiteFolder() const override;
     FillerPath suiteFillerFolder() const override;
 };

--- a/retesteth/testSuites/StateTests.cpp
+++ b/retesteth/testSuites/StateTests.cpp
@@ -529,7 +529,7 @@ DataObject StateTestSuite::doTests(DataObject const& _input, TestSuiteOptions& _
             {
                 // Change the tests instead??
                 DataObject& _inputRef = const_cast<DataObject&>(_input);
-                DataObject& _infoRef = _inputRef.getSubObjectsUnsafe().at(0).atKeyUnsafe("_info");
+                DataObject& _infoRef = _inputRef.getSubObjectsUnsafe().at(0).getContent().atKeyUnsafe("_info");
                 _infoRef.renameKey("filledwith", "filling-rpc-server");
                 _infoRef["filling-tool-version"] = "testeth";
             }

--- a/retesteth/testSuites/StateTests.h
+++ b/retesteth/testSuites/StateTests.h
@@ -31,7 +31,7 @@ class StateTestSuite: public TestSuite
 public:
     StateTestSuite();
     StateTestSuite(int){};
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestSuite::TestPath suiteFolder() const override;
     TestSuite::FillerPath suiteFillerFolder() const override;
 };

--- a/retesteth/testSuites/TestFixtures.h
+++ b/retesteth/testSuites/TestFixtures.h
@@ -108,6 +108,12 @@ public:
             return;
         }
 
+        if (casename == "bcForgedTest")
+        {
+            ETH_STDOUT_MESSAGE("Skipping " + casename + " because bigint exceptions run in progress!");
+            return;
+        }
+
         suite.runAllTestsInFolder(casename);
         test::TestOutputHelper::get().markTestFolderAsFinished(suiteFillerPath, casename);
     }

--- a/retesteth/testSuites/blockchain/BlockchainTestLogic.cpp
+++ b/retesteth/testSuites/blockchain/BlockchainTestLogic.cpp
@@ -252,8 +252,9 @@ DataObject DoTests(DataObject const& _input, TestSuite::TestSuiteOptions& _opt)
         {
             // Change the tests instead??
             DataObject& _inputRef = const_cast<DataObject&>(_input);
-            for (auto& el : _inputRef.getSubObjectsUnsafe())
+            for (auto& el2 : _inputRef.getSubObjectsUnsafe())
             {
+                DataObject& el = el2.getContent();
                 DataObject& _infoRef = el.atKeyUnsafe("_info");
                 _infoRef.renameKey("filledwith", "filling-rpc-server");
                 _infoRef["filling-tool-version"] = "testeth";

--- a/retesteth/testSuites/blockchain/BlockchainTestLogic.cpp
+++ b/retesteth/testSuites/blockchain/BlockchainTestLogic.cpp
@@ -101,7 +101,9 @@ void RunTest(BlockchainTestInFilled const& _test, TestSuite::TestSuiteOptions co
                 printVmTrace(session, tr->hash(), latestBlock.header()->stateRoot());
         }
 
-        bool condition = latestBlock.header().getCContent() == tblock.header().getCContent();
+        spDataObject remoteHeader = latestBlock.header()->asDataObject();
+        spDataObject testHeader = tblock.header()->asDataObject();
+        bool condition = remoteHeader->asJson(0, false) == testHeader->asJson(0, false);
         /*if (_opt.isLegacyTests)
         {
             inTestHeader = bdata.atKey("blockHeader");  // copy!!!
@@ -125,8 +127,7 @@ void RunTest(BlockchainTestInFilled const& _test, TestSuite::TestSuiteOptions co
         {
             string errField;
             message = "Client return HEADER vs Test HEADER: \n";
-            message += compareBlockHeaders(
-                latestBlock.header()->asDataObject(), tblock.header()->asDataObject(), errField);
+            message += compareBlockHeaders(remoteHeader.getCContent(), testHeader.getCContent(), errField);
         }
         ETH_ERROR_REQUIRE_MESSAGE(
             condition, "Client report different blockheader after importing the rlp than expected by test! \n" + message);
@@ -209,9 +210,9 @@ void RunTest(BlockchainTestInFilled const& _test, TestSuite::TestSuiteOptions co
     }
 }
 
-DataObject DoTests(DataObject const& _input, TestSuite::TestSuiteOptions& _opt)
+spDataObject DoTests(DataObject const& _input, TestSuite::TestSuiteOptions& _opt)
 {
-    DataObject tests;
+    spDataObject tests(new DataObject());
     if (_opt.doFilling)
     {
         BlockchainTestFiller testFiller(_input);
@@ -238,9 +239,9 @@ DataObject DoTests(DataObject const& _input, TestSuite::TestSuiteOptions& _opt)
             }
 
             // One blockchain test generate many tests for each network
-            DataObject filledTests = FillTest(bcTest, _opt);
-            for (auto const& t : filledTests.getSubObjects())
-                tests.addSubObject(t);
+            spDataObject filledTests = FillTest(bcTest, _opt);
+            for (auto const& t : (*filledTests).getSubObjects())
+                (*tests).addSubObject(t);
             TestOutputHelper::get().registerTestRunSuccess();
         }
     }

--- a/retesteth/testSuites/blockchain/BlockchainTestLogic.h
+++ b/retesteth/testSuites/blockchain/BlockchainTestLogic.h
@@ -13,11 +13,11 @@ using namespace std;
 namespace test
 {
 /// Generate blockchain test from filler
-DataObject FillTest(BlockchainTestInFiller const& _testObject, TestSuite::TestSuiteOptions const& _opt);
+spDataObject FillTest(BlockchainTestInFiller const& _testObject, TestSuite::TestSuiteOptions const& _opt);
 
 /// Read and execute the test from the file
 void RunTest(BlockchainTestInFilled const& _testObject, TestSuite::TestSuiteOptions const& _opt);
 
 /// Parse blockchain test fillers and Run/Fill tests
-DataObject DoTests(DataObject const& _input, TestSuite::TestSuiteOptions& _opt);
+spDataObject DoTests(DataObject const& _input, TestSuite::TestSuiteOptions& _opt);
 }

--- a/retesteth/testSuites/blockchain/BlockchainTests.cpp
+++ b/retesteth/testSuites/blockchain/BlockchainTests.cpp
@@ -33,25 +33,25 @@ namespace fs = boost::filesystem;
 namespace test
 {
 /// !!! DataObject return without reference!!! must be SP!!!
-DataObject BlockchainTestTransitionSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
+spDataObject BlockchainTestTransitionSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
 {
     _opt.allowInvalidBlocks = true;
     return DoTests(_input, _opt);
 }
 
-DataObject BlockchainTestInvalidSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
+spDataObject BlockchainTestInvalidSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
 {
     _opt.allowInvalidBlocks = true;
     return DoTests(_input, _opt);
 }
 
-DataObject BlockchainTestValidSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
+spDataObject BlockchainTestValidSuite::doTests(DataObject const& _input, TestSuiteOptions& _opt) const
 {
     _opt.allowInvalidBlocks = false;
     return DoTests(_input, _opt);
 }
 
-DataObject LegacyConstantinopleBlockchainInvalidTestSuite::doTests(
+spDataObject LegacyConstantinopleBlockchainInvalidTestSuite::doTests(
     DataObject const& _input, TestSuiteOptions& _opt) const
 {
     _opt.allowInvalidBlocks = true;
@@ -59,7 +59,7 @@ DataObject LegacyConstantinopleBlockchainInvalidTestSuite::doTests(
     return DoTests(_input, _opt);
 }
 
-DataObject LegacyConstantinopleBlockchainValidTestSuite::doTests(
+spDataObject LegacyConstantinopleBlockchainValidTestSuite::doTests(
     DataObject const& _input, TestSuiteOptions& _opt) const
 {
     _opt.allowInvalidBlocks = false;
@@ -67,7 +67,7 @@ DataObject LegacyConstantinopleBlockchainValidTestSuite::doTests(
     return DoTests(_input, _opt);
 }
 
-DataObject LegacyConstantinopleBCGeneralStateTestsSuite::doTests(
+spDataObject LegacyConstantinopleBCGeneralStateTestsSuite::doTests(
     DataObject const& _input, TestSuiteOptions& _opt) const
 {
     _opt.isLegacyTests = true;

--- a/retesteth/testSuites/blockchain/BlockchainTests.h
+++ b/retesteth/testSuites/blockchain/BlockchainTests.h
@@ -17,7 +17,7 @@ namespace test
 class BlockchainTestValidSuite : public TestSuite
 {
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestPath suiteFolder() const override;
     FillerPath suiteFillerFolder() const override;
 };
@@ -26,7 +26,7 @@ public:
 class BlockchainTestInvalidSuite : public TestSuite
 {
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestPath suiteFolder() const override;
     FillerPath suiteFillerFolder() const override;
 };
@@ -35,7 +35,7 @@ public:
 class BlockchainTestTransitionSuite : public TestSuite
 {
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestPath suiteFolder() const override;
     FillerPath suiteFillerFolder() const override;
 };
@@ -66,7 +66,7 @@ class LegacyConstantinopleBCGeneralStateTestsSuite : public BlockchainTestValidS
 protected:
     bool legacyTestSuiteFlag() const override { return  true; }
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     test::TestSuite::TestPath suiteFolder() const override;
     test::TestSuite::FillerPath suiteFillerFolder() const override;
 };
@@ -77,7 +77,7 @@ class LegacyConstantinopleBlockchainInvalidTestSuite : public BlockchainTestInva
 protected:
     bool legacyTestSuiteFlag() const override { return  true; }
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestPath suiteFolder() const override
     {
         return TestSuite::TestPath(
@@ -95,7 +95,7 @@ class LegacyConstantinopleBlockchainValidTestSuite : public BlockchainTestValidS
 protected:
     bool legacyTestSuiteFlag() const override { return  true; }
 public:
-    DataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
+    spDataObject doTests(DataObject const& _input, TestSuiteOptions& _opt) const override;
     TestPath suiteFolder() const override
     {
         return TestSuite::TestPath(

--- a/retesteth/testSuites/blockchain/fillers/TestBlock.cpp
+++ b/retesteth/testSuites/blockchain/fillers/TestBlock.cpp
@@ -9,9 +9,10 @@ TestBlock::TestBlock(BYTES const& _rlp, string const& _chainName, FORK const& _c
     m_rawRLP = spBYTES(_rlp.copy());
 }
 
-DataObject TestBlock::asDataObject() const
+spDataObject TestBlock::asDataObject() const
 {
-    DataObject res;
+    spDataObject _res(new DataObject());
+    DataObject& res = _res.getContent();
     res["chainname"] = m_chainName;
     // res["chainnetwork"] = m_chainNet->asString();
     res["blocknumber"] = m_blockNumber->asDecString();
@@ -21,17 +22,18 @@ DataObject TestBlock::asDataObject() const
     // No test objects was registered
     if (!m_block.isEmpty())
     {
-        res["uncleHeaders"] = DataObject(DataType::Array);
+        res.atKeyPointer("uncleHeaders") = spDataObject(new DataObject(DataType::Array));
         for (auto const& un : m_block->uncles())
             res["uncleHeaders"].addArrayObject(un->asDataObject());
-        res["blockHeader"] = m_block->header()->asDataObject();
-        res["transactions"] = DataObject(DataType::Array);
+        res.atKeyPointer("blockHeader") = m_block->header()->asDataObject();
+        res.atKeyPointer("transactions") = spDataObject(new DataObject(DataType::Array));
         for (auto const& tr : m_block->transactions())
             res["transactions"].addArrayObject(tr->asDataObject(ExportOrder::OldStyle));
 
         for (auto const& trSequence : m_transactionExecOrder)
         {
-            DataObject trInfo;
+            spDataObject _trInfo(new DataObject());
+            DataObject& trInfo = _trInfo.getContent();
             BYTES const& b = std::get<0>(trSequence);
             string const& v = std::get<1>(trSequence);
             trInfo["rawBytes"] = b.asString();
@@ -42,10 +44,10 @@ DataObject TestBlock::asDataObject() const
                 trInfo["valid"] = "false";
                 trInfo["exception"] = v;
             }
-            res["transactionSequence"].addArrayObject(trInfo);
+            res["transactionSequence"].addArrayObject(_trInfo);
         }
     }
 
     res["rlp"] = m_rawRLP->asString();
-    return res;
+    return _res;
 }

--- a/retesteth/testSuites/blockchain/fillers/TestBlock.h
+++ b/retesteth/testSuites/blockchain/fillers/TestBlock.h
@@ -42,7 +42,7 @@ public:
     void setDoNotExport(bool _flag) { m_doNotExport = _flag; }
     bool isDoNotExport() const { return m_doNotExport; }
 
-    DataObject asDataObject() const;
+    spDataObject asDataObject() const;
 
 private:
     TestBlock() {}

--- a/retesteth/testSuites/blockchain/fillers/TestBlockchain.cpp
+++ b/retesteth/testSuites/blockchain/fillers/TestBlockchain.cpp
@@ -193,13 +193,13 @@ GCP_SPointer<EthGetBlockBy> TestBlockchain::mineBlock(
             if (exception.empty())
                 ETH_WARNING(
                     "TestBlockchain::mineBlock transaction has unexpectedly failed to be mined (see logs --verbosity 6): \n" +
-                    trInTest.tr().asDataObject().asJson() + "\nReason: `" + reason + "`");
+                    trInTest.tr().asDataObject()->asJson() + "\nReason: `" + reason + "`");
             else
             {
                string const& expectedReason = Options::getCurrentConfig().translateException(exception);
                if (reason.find(expectedReason) == string::npos)
                {
-                   ETH_WARNING(trInTest.tr().asDataObject().asJson());
+                   ETH_WARNING(trInTest.tr().asDataObject()->asJson());
                    ETH_ERROR_MESSAGE(string("Transaction rejecetd but due to a different reason: \n") +
                       "Expected reason: `" + expectedReason + "` (" + exception + ")\n" +
                       "Client reason: `" + reason
@@ -211,7 +211,7 @@ GCP_SPointer<EthGetBlockBy> TestBlockchain::mineBlock(
         {
             if (!exception.empty())
                 ETH_WARNING("TestBlockchain::mineBlock transaction expected to failed with `"+ exception +"` but mined good: \n" +
-                            trInTest.tr().asDataObject().asJson());
+                            trInTest.tr().asDataObject()->asJson());
         }
     }
 
@@ -242,8 +242,8 @@ spBlockHeader TestBlockchain::mineNextBlockAndRevert()
 
     // assign a random coinbase for an uncle block to avoid UncleIsAncestor exception
     // otherwise this uncle would be similar to a block mined
-    DataObject head = nextBlock.header()->asDataObject();
-    head["coinbase"] = "0xb94f5374fce5ed0000000097c15331677e6ebf0b";  // FH20::random().asString();
+    spDataObject head = nextBlock.header()->asDataObject();
+    (*head)["coinbase"] = "0xb94f5374fce5ed0000000097c15331677e6ebf0b";  // FH20::random().asString();
     return readBlockHeader(head);
 }
 

--- a/retesteth/unitTests/dataObjectTests.cpp
+++ b/retesteth/unitTests/dataObjectTests.cpp
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(dataobject_bracers)
 
     try
     {
-        DataObject a = ConvertJsoncppStringToData(data);
-        BOOST_REQUIRE(a.atKey("logs").at(0).atKey("removed").asBool() == false);
+        spDataObject a = ConvertJsoncppStringToData(data);
+        BOOST_REQUIRE(a->atKey("logs").at(0).atKey("removed").asBool() == false);
     }
     catch (DataObjectException const& _ex)
     {
@@ -74,8 +74,8 @@ BOOST_AUTO_TEST_CASE(dataobject_EscapeChars)
     )";
     try
     {
-        DataObject a = ConvertJsoncppStringToData(data);
-        BOOST_REQUIRE(a.atKey("error").atKey("message").asString() ==
+        spDataObject a = ConvertJsoncppStringToData(data);
+        BOOST_REQUIRE(a->atKey("error").atKey("message").asString() ==
                       "invalid argument 0: invalid hex or decimal integer \\\"0x\\\"");
     }
     catch (DataObjectException const&)
@@ -183,8 +183,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson1)
             }
         }
     )";
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson2)
@@ -195,8 +195,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson2)
             }
         }
     )";
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson3)
@@ -210,8 +210,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson3)
         }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{\"key\":[]}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{\"key\":[]}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson4)
@@ -227,8 +227,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson4)
         }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{\"key\":[\"aaa\",\"bbb\"]}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{\"key\":[\"aaa\",\"bbb\"]}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson5)
@@ -244,8 +244,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson5)
         }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{\"key\":[12,34]}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{\"key\":[12,34]}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson5b)
@@ -266,8 +266,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson5b)
         }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data, "key");
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{\"key\":[12,34]}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data, "key");
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{\"key\":[12,34]}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson6)
@@ -280,8 +280,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson6)
         }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"name\":{\"key\":-123}}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"name\":{\"key\":-123}}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson7)
@@ -346,8 +346,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson7)
     string const res =
         R"({"name":{"_info":{"comment":"A tesesult","filledwith":"testee5c"},"blocks":[{"blockHeader":{"difficulty":"0x020000","extraData":""},"rlp":"0xf90262f0","transactions":[{"data":"0x","value":"0x0186a0"}],"uncleHeaders":[]}],"genesisBlockHeader":{"number":"0x00"},"genesisRLP":"0xf9c6f04171167ec0c0","lastblockhash":"0x00606595b80acde5","network":"Homestead","postState":{"0x095e7baea6a6c7c4c2dfeb977efac326af552d87":{"storage":{"0x00":"0x02"}},"0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba":{"storage":{}},"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b":{"nonce":"0x01","storage":{}}},"pre":{"0x095e7baea6a6c7c4c2dfeb977efac326af552d87":{},"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b":{}},"sealEngine":"NoProof"}})";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == res);
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == res);
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson8)
@@ -365,8 +365,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson8)
         }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"code\":\"}\"}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"code\":\"}\"}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson9)
@@ -379,8 +379,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson9)
     }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"array\":[1,2,-1,5,3]}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"array\":[1,2,-1,5,3]}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson10)
@@ -393,8 +393,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson10)
     }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.asJson(0, false) == "{\"array\":[\"1\",\"2\",\"-1\",\"5\",\"3\"]}");
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->asJson(0, false) == "{\"array\":[\"1\",\"2\",\"-1\",\"5\",\"3\"]}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson11)
@@ -414,8 +414,8 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson11)
 }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
-    BOOST_CHECK(dObj.count("forks"));
+    spDataObject dObj = ConvertJsoncppStringToData(data);
+    BOOST_CHECK(dObj->count("forks"));
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson12)
@@ -443,10 +443,10 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson12)
     }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
+    spDataObject dObj = ConvertJsoncppStringToData(data);
     string const res =
         R"({"Byzantium":[{"hash":"0x","indexes":{"data":0,"value":0}}],"Constantinople":[{"hash":"0x","indexes":{"data":0,"value":0}}]})";
-    BOOST_CHECK(dObj.asJson(0, false) == res);
+    BOOST_CHECK(dObj->asJson(0, false) == res);
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson13)
@@ -478,18 +478,18 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson13)
     }
     )";
 
-    DataObject dObj = ConvertJsoncppStringToData(data);
+    spDataObject dObj = ConvertJsoncppStringToData(data);
     string const res =
         R"({"expect":[{"result":{"0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6":{}}},{"result":{"0xd27e800c69122409ac5609fe4df903745f3988a0":{"storage":{"0x01":"0x01"}}}}]})";
-    BOOST_CHECK(dObj.asJson(0, false) == res);
+    BOOST_CHECK(dObj->asJson(0, false) == res);
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson14)
 {
     string data = R"( {"jsonrpc":"2.0","id":1,"result":true}   )";
-    DataObject dObj = ConvertJsoncppStringToData(data);
+    spDataObject dObj = ConvertJsoncppStringToData(data);
     string res = R"({"jsonrpc":"2.0","id":1,"result":true})";
-    BOOST_CHECK(dObj.asJson(0, false) == res);
+    BOOST_CHECK(dObj->asJson(0, false) == res);
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_readJson15)
@@ -502,9 +502,9 @@ BOOST_AUTO_TEST_CASE(dataobject_readJson15)
                     "object" : null
                 }
        )";
-    DataObject dObj = ConvertJsoncppStringToData(data);
+    spDataObject dObj = ConvertJsoncppStringToData(data);
     string res = R"({"array":[null],"object":null})";
-    BOOST_CHECK(dObj.asJson(0, false) == res);
+    BOOST_CHECK(dObj->asJson(0, false) == res);
 }
 
 
@@ -771,8 +771,8 @@ BOOST_AUTO_TEST_CASE(dataobject_jsonOrder2)
         "storage" : {
         }
     })";
-    DataObject dObj = ConvertJsoncppStringToData(data, string(), true);
-    BOOST_CHECK(dObj.at(dObj.getSubObjects().size() - 2).getKey() == "nonce");
+    spDataObject dObj = ConvertJsoncppStringToData(data, string(), true);
+    BOOST_CHECK(dObj->at(dObj->getSubObjects().size() - 2).getKey() == "nonce");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_jsonOrder)
@@ -794,18 +794,21 @@ BOOST_AUTO_TEST_CASE(dataobject_jsonOrder)
 
 BOOST_AUTO_TEST_CASE(dataobject_replace)
 {
-    DataObject data;
-    DataObject data2;
-    DataObject data3;
+    spDataObject _data(new DataObject());
+    spDataObject _data2(new DataObject());
+    spDataObject _data3(new DataObject());
+    DataObject& data = _data.getContent();
+    DataObject& data2 = _data2.getContent();
+    DataObject& data3 = _data3.getContent();
     data2.setKey("key2");
     data2.setString("value2");
     data3.setKey("key3");
     data3.setString("value3");
 
-    data["field1"] = data3; // null object with key "field1" keep the key "field1"
+    data["field1"].copyFrom(data3); // null object with key "field1" keep the key "field1"
     BOOST_CHECK(data.asJson(0,false) == "{\"field1\":\"value3\"}");
 
-    data["field1"] = data2; // not null object with key "field1" replaces the key "field1" to data2's key
+    data["field1"].copyFrom(data2); // not null object with key "field1" replaces the key "field1" to data2's key
     BOOST_CHECK(data.asJson(0,false) == "{\"key2\":\"value2\"}");
 }
 
@@ -825,7 +828,7 @@ BOOST_AUTO_TEST_CASE(dataobject_arrayhell)
                     ]
                 ]
     })";
-    DataObject dObj = ConvertJsoncppStringToData(data, string(), true);
+    spDataObject dObj = ConvertJsoncppStringToData(data, string(), true);
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_besuresponse)
@@ -854,11 +857,11 @@ BOOST_AUTO_TEST_CASE(dataobject_besuresponse)
             } ]
           }
         })";
-    DataObject dObj = ConvertJsoncppStringToData(data, string(), true);
+    spDataObject dObj = ConvertJsoncppStringToData(data, string(), true);
 
     string const expectedParse =
         R"({"result":{"transactions":[{"blockHash":"0xac7b82af234ef01bf4d24a3b9c22c2de091c6f71ec04d51ff23bd780533d999f","blockNumber":"0x1","chainId":null,"from":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","gas":"0x7a120","gasPrice":"0xa","hash":"0x225117089dee26945644798e2c64d3117f55c95c7cf5509f7176de4b3af5202d","input":"0x604b80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463cbf0b0c08114602d57005b60006004358073ffffffffffffffffffffffffffffffffffffffff16ff","nonce":"0x0","publicKey":"0x3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3","r":"0xe7d3c664c49aa9f5ce4eb76c8547450466262a78bd093160f492ea0853c68e9","raw":"0xf8a5800a8307a1208081ffb857604b80600c6000396000f3007c01000000000000000000000000000000000000000000000000000000006000350463cbf0b0c08114602d57005b60006004358073ffffffffffffffffffffffffffffffffffffffff16ff1ca00e7d3c664c49aa9f5ce4eb76c8547450466262a78bd093160f492ea0853c68e9a03f843e72210ff1da4fd9e375339872bcf0fad05c014e280ffc755e173700dd62","s":"0x3f843e72210ff1da4fd9e375339872bcf0fad05c014e280ffc755e173700dd62","to":null,"transactionIndex":"0x0","v":"0x1c","value":"0xff"}]}})";
-    BOOST_CHECK(dObj.asJson(0, false) == expectedParse);
+    BOOST_CHECK(dObj->asJson(0, false) == expectedParse);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/retesteth/unitTests/dataObjectTests.cpp
+++ b/retesteth/unitTests/dataObjectTests.cpp
@@ -794,22 +794,19 @@ BOOST_AUTO_TEST_CASE(dataobject_jsonOrder)
 
 BOOST_AUTO_TEST_CASE(dataobject_replace)
 {
-    spDataObject _data(new DataObject());
-    spDataObject _data2(new DataObject());
-    spDataObject _data3(new DataObject());
-    DataObject& data = _data.getContent();
-    DataObject& data2 = _data2.getContent();
-    DataObject& data3 = _data3.getContent();
-    data2.setKey("key2");
-    data2.setString("value2");
-    data3.setKey("key3");
-    data3.setString("value3");
+    spDataObject data(new DataObject());
+    spDataObject data2(new DataObject());
+    spDataObject data3(new DataObject());
+    (*data2).setKey("key2");
+    (*data2).setString("value2");
+    (*data3).setKey("key3");
+    (*data3).setString("value3");
 
-    data["field1"].copyFrom(data3); // null object with key "field1" keep the key "field1"
-    BOOST_CHECK(data.asJson(0,false) == "{\"field1\":\"value3\"}");
+    (*data).atKeyPointer("field1") = data3; // null object with key "field1" keep the key "field1"
+    BOOST_CHECK(data->asJson(0,false) == "{\"field1\":\"value3\"}");
 
-    data["field1"].copyFrom(data2); // not null object with key "field1" replaces the key "field1" to data2's key
-    BOOST_CHECK(data.asJson(0,false) == "{\"key2\":\"value2\"}");
+    (*data).atKeyPointer("field1") = data2; // not null object with key "field1" replaces the key "field1" to data2's key
+    BOOST_CHECK(data->asJson(0,false) == "{\"key2\":\"value2\"}");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_arrayhell)

--- a/retesteth/unitTests/ethObjectsTests.cpp
+++ b/retesteth/unitTests/ethObjectsTests.cpp
@@ -40,13 +40,13 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_lastToFirst)
 	data["key1"] = "data1";
 	data["key2"] = "data2";
 	data["key3"] = "data3";
-	data.setKeyPos("key3", 0);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data3");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data2");
+    data.setKeyPos("key3", 0);
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data2");
     TestOutputHelper::registerTestRunSuccess();
 }
 
@@ -57,12 +57,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_lastToMid)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key3", 1);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data3");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data2");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_lastTolast)
@@ -72,12 +72,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_lastTolast)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key3", 2);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data3");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToFirst)
@@ -87,12 +87,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToFirst)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key2", 0);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data3");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midTomid)
@@ -102,12 +102,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midTomid)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key2", 1);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data3");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToLast)
@@ -117,12 +117,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToLast)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key2", 2);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data3");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data2");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToLast2)
@@ -133,14 +133,14 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToLast2)
 	data["key3"] = "data3";
 	data["key4"] = "data4";
 	data.setKeyPos("key2", 3);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data3");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key4");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data4");
-	BOOST_CHECK(data.getSubObjects().at(3).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(3).asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key4");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data4");
+    BOOST_CHECK(data.getSubObjects().at(3)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(3)->asString() == "data2");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToMid2)
@@ -151,14 +151,14 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_midToMid2)
 	data["key3"] = "data3";
 	data["key4"] = "data4";
 	data.setKeyPos("key2", 2);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data3");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(3).getKey() == "key4");
-	BOOST_CHECK(data.getSubObjects().at(3).asString() == "data4");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(3)->getKey() == "key4");
+    BOOST_CHECK(data.getSubObjects().at(3)->asString() == "data4");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_firstTofirst)
@@ -168,12 +168,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_firstTofirst)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key1", 0);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data3");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_firstTomid)
@@ -183,12 +183,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_firstTomid)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key1", 1);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data1");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data3");
 }
 
 BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_firstToLast)
@@ -198,12 +198,12 @@ BOOST_AUTO_TEST_CASE(dataobject_setKeyPos_firstToLast)
 	data["key2"] = "data2";
 	data["key3"] = "data3";
 	data.setKeyPos("key1", 2);
-	BOOST_CHECK(data.getSubObjects().at(0).getKey() == "key2");
-	BOOST_CHECK(data.getSubObjects().at(0).asString() == "data2");
-	BOOST_CHECK(data.getSubObjects().at(1).getKey() == "key3");
-	BOOST_CHECK(data.getSubObjects().at(1).asString() == "data3");
-	BOOST_CHECK(data.getSubObjects().at(2).getKey() == "key1");
-	BOOST_CHECK(data.getSubObjects().at(2).asString() == "data1");
+    BOOST_CHECK(data.getSubObjects().at(0)->getKey() == "key2");
+    BOOST_CHECK(data.getSubObjects().at(0)->asString() == "data2");
+    BOOST_CHECK(data.getSubObjects().at(1)->getKey() == "key3");
+    BOOST_CHECK(data.getSubObjects().at(1)->asString() == "data3");
+    BOOST_CHECK(data.getSubObjects().at(2)->getKey() == "key1");
+    BOOST_CHECK(data.getSubObjects().at(2)->asString() == "data1");
 }
 
 BOOST_AUTO_TEST_CASE(object_stringIntegerType_correctHex)

--- a/retesteth/unitTests/ethObjectsTests.cpp
+++ b/retesteth/unitTests/ethObjectsTests.cpp
@@ -261,207 +261,207 @@ void testCompareResult(DataObject const& _exp, DataObject const& _post, CompareR
 
 BOOST_AUTO_TEST_CASE(compareStates_noError)
 {
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::Success);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_missingAccount)
 {
-    DataObject expectData;
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::MissingExpectedAccount);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_shouldnoexist)
 {
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["shouldnotexist"] = "1";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["shouldnotexist"] = "1";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::AccountShouldNotExist);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_wrongBalance)
 {
-    DataObject expectData;
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::IncorrectBalance);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_wrongNonce)
 {
-    DataObject expectData;
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082123";
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x02";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082123";
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x02";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82123";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::IncorrectNonce);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_multipleError)
 {
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082123";
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x02";
-    expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x02";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082123";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082123";
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x02";
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x02";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082123";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::IncorrectCode, 3);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_accountShouldNotExistAndItsNot)
 {
-	DataObject expectData;
-	expectData["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["shouldnotexist"] = "1";
-	DataObject postData;
-	postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
-	postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-	postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-	postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["shouldnotexist"] = "1";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::Success);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_prefixedZeros)
 {
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] =
-        DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") =
+        spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::Success);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_prefixedZeros2)
 {
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] =
-        DataObject(DataType::Object);
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x82124";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") =
+        spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::Success);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_storageEmpty)
 {
-    DataObject expectStorage;
-    expectStorage["0x01"] = "0x00";
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = expectStorage;
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] =
-        DataObject(DataType::Object);
+    spDataObject expectStorage(new DataObject());
+    (*expectStorage)["0x01"] = "0x00";
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = expectStorage;
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") =
+        spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::Success);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_storageIncorrect)
 {
-    DataObject expectStorage;
-    expectStorage["0x01"] = "0x01";
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = expectStorage;
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] =
-        DataObject(DataType::Object);
+    spDataObject expectStorage(new DataObject());
+    (*expectStorage)["0x01"] = "0x01";
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = expectStorage;
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") =
+        spDataObject(new DataObject(DataType::Object));
     testCompareResult(expectData, postData, CompareResult::IncorrectStorage);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_storageCorrect)
 {
-    DataObject expectStorage;
-    expectStorage["0x01"] = "0x01";
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = expectStorage;
-    DataObject postStorage;
-    postStorage["0x01"] = "0x01";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = postStorage;
+    spDataObject expectStorage(new DataObject());
+    (*expectStorage)["0x01"] = "0x01";
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = expectStorage;
+    spDataObject postStorage(new DataObject());
+    (*postStorage)["0x01"] = "0x01";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = postStorage;
     testCompareResult(expectData, postData, CompareResult::Success);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_storageMissingOnPost)
 {
-    DataObject expectStorage;
-    expectStorage["0x01"] = "0x01";
-    expectStorage["0x02"] = "0x01";
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = expectStorage;
-    DataObject postStorage;
-    postStorage["0x01"] = "0x01";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = postStorage;
+    spDataObject expectStorage(new DataObject());
+    (*expectStorage)["0x01"] = "0x01";
+    (*expectStorage)["0x02"] = "0x01";
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = expectStorage;
+    spDataObject postStorage(new DataObject());
+    (*postStorage)["0x01"] = "0x01";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = postStorage;
     testCompareResult(expectData, postData, CompareResult::IncorrectStorage);
 }
 
 BOOST_AUTO_TEST_CASE(compareStates_storageMissingOnExpect)
 {
-    DataObject expectStorage;
-    expectStorage["0x01"] = "0x01";
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = expectStorage;
-    DataObject postStorage;
-    postStorage["0x01"] = "0x01";
-    postStorage["0x02"] = "0x01";
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = postStorage;
+    spDataObject expectStorage(new DataObject());
+    (*expectStorage)["0x01"] = "0x01";
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = expectStorage;
+    spDataObject postStorage(new DataObject());
+    (*postStorage)["0x01"] = "0x01";
+    (*postStorage)["0x02"] = "0x01";
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = postStorage;
     testCompareResult(expectData, postData, CompareResult::IncorrectStorage, 2);
 }
 
@@ -469,22 +469,22 @@ void ExpectVsPost(string const& _expectKey, string const& _expectVal, string con
     CompareResult _res, string const& _doubleVal = "0x02", size_t _errCount = 2)
 {
     ETH_LOG("Exp(" + _expectKey + ":" + _expectVal + ") vs Post(" + _postKey + "," + _postVal + ") dd: " + _doubleVal, 0);
-    DataObject expectStorage(DataType::Object);
+    spDataObject expectStorage(new DataObject(DataType::Object));
     if (_expectKey != "--")
-        expectStorage[_expectKey] = _expectVal;
-    expectStorage["0x02"] = "0x02";
-    DataObject expectData;
-    expectData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = expectStorage;
-    DataObject postStorage(DataType::Object);
+        (*expectStorage)[_expectKey] = _expectVal;
+    (*expectStorage)["0x02"] = "0x02";
+    spDataObject expectData(new DataObject());
+    (*expectData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = expectStorage;
+    spDataObject postStorage(new DataObject(DataType::Object));
     if (_postKey != "--")
-        postStorage[_postKey] = _postVal;
-    postStorage["0x02"] = _doubleVal;
+        (*postStorage)[_postKey] = _postVal;
+    (*postStorage)["0x02"] = _doubleVal;
 
-    DataObject postData;
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
-    postData["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["storage"] = postStorage;
+    spDataObject postData(new DataObject());
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["balance"] = "0x082124";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["code"] = "0x1234";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"]["nonce"] = "0x01";
+    (*postData)["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"].atKeyPointer("storage") = postStorage;
     testCompareResult(expectData, postData, _res, _errCount);
 }
 

--- a/retesteth/unitTests/expectSectionTests.cpp
+++ b/retesteth/unitTests/expectSectionTests.cpp
@@ -39,9 +39,11 @@ string const expectSectionCommon = R"(
 
 StateTestFillerExpectSection makeExpectSection(string const& _tr, string const& _exp)
 {
+    spDataObject res = ConvertJsoncppStringToData(_tr);
     spStateTestFillerTransaction spTransaction =
-        spStateTestFillerTransaction(new StateTestFillerTransaction(ConvertJsoncppStringToData(_tr)));
-    return StateTestFillerExpectSection(ConvertJsoncppStringToData(_exp), spTransaction);
+        spStateTestFillerTransaction(new StateTestFillerTransaction(res));
+    spDataObject res2 = ConvertJsoncppStringToData(_exp);
+    return StateTestFillerExpectSection(res2, spTransaction);
 }
 
 BOOST_FIXTURE_TEST_SUITE(ExpectSectionSuite, Initializer)

--- a/retesteth/unitTests/memoryLeakTests.cpp
+++ b/retesteth/unitTests/memoryLeakTests.cpp
@@ -70,6 +70,9 @@ BOOST_AUTO_TEST_CASE(smartPointerVector)
     BOOST_CHECK(vec.at(1)->asBigInt() == 24);
     A.getContent() += 12;
     BOOST_CHECK(vec.at(1)->asBigInt() == 36);
+
+    //A = B;
+    //BOOST_CHECK(vec.at(1)->asBigInt() == 13);
 }
 
 

--- a/retesteth/unitTests/memoryLeakTests.cpp
+++ b/retesteth/unitTests/memoryLeakTests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(recalculateHash)
         "uncleHash" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
         "baseFeePerGas" : "0x0e"
     })";
-    DataObject data = dataobject::ConvertJsoncppStringToData(str);
+    spDataObject data = dataobject::ConvertJsoncppStringToData(str);
     spBlockHeader1559 header(new BlockHeader1559(data));
     header.getContent().recalculateHash();
 }

--- a/retesteth/unitTests/memoryLeakTests.cpp
+++ b/retesteth/unitTests/memoryLeakTests.cpp
@@ -39,4 +39,38 @@ BOOST_AUTO_TEST_CASE(recalculateHash)
     header.getContent().recalculateHash();
 }
 
+BOOST_AUTO_TEST_CASE(smartPointer)
+{
+    spVALUE A(new VALUE(12));
+    spVALUE B;
+
+    B = A;
+    BOOST_CHECK(B->asBigInt() == 12);
+    BOOST_CHECK(B->asBigInt() == A->asBigInt());
+
+    B.getContent() += 12;
+    BOOST_CHECK(A->asBigInt() == 24);
+}
+
+BOOST_AUTO_TEST_CASE(smartPointerVector)
+{
+    spVALUE A(new VALUE(12));
+    std::vector<spVALUE> vec;
+    vec.push_back(A);
+
+    BOOST_CHECK(vec.at(0)->asBigInt() == 12);
+    A.getContent() += 12;
+
+    BOOST_CHECK(vec.at(0)->asBigInt() == 24);
+
+    spVALUE B(new VALUE(13));
+    vec.insert(vec.begin(), B);
+
+    BOOST_CHECK(vec.at(0)->asBigInt() == 13);
+    BOOST_CHECK(vec.at(1)->asBigInt() == 24);
+    A.getContent() += 12;
+    BOOST_CHECK(vec.at(1)->asBigInt() == 36);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/retesteth/unitTests/memoryLeakTests.cpp
+++ b/retesteth/unitTests/memoryLeakTests.cpp
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE(smartPointerVector)
     A.getContent() += 12;
     BOOST_CHECK(vec.at(1)->asBigInt() == 36);
 
-    //A = B;
-    //BOOST_CHECK(vec.at(1)->asBigInt() == 13);
+    // smart pointer changed outside of vector does not affect smart pointer stored in vector
+    A = B;
+    BOOST_CHECK(vec.at(1)->asBigInt() != 13);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/retesteth/unitTests/trDataCompileTest.cpp
+++ b/retesteth/unitTests/trDataCompileTest.cpp
@@ -36,21 +36,21 @@ BOOST_FIXTURE_TEST_SUITE(trDataCompileSuite, TestOutputHelperFixture)
 BOOST_AUTO_TEST_CASE(compileRaw)
 {
     StateTestFillerTransaction tr = makeTransaction({":raw 0x1234"});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x1234");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x1234");
 }
 
 BOOST_AUTO_TEST_CASE(compileRawLabel)
 {
     StateTestFillerTransaction tr = makeTransaction({":label sample :raw 0x1234"});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x1234");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x1234");
 }
 
 BOOST_AUTO_TEST_CASE(compileRawArray)
 {
     StateTestFillerTransaction tr = makeTransaction({":raw 0x1234", ":raw 0x2244"});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x1234");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString() == "0x2244");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x1234");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString() == "0x2244");
 }
 
 BOOST_AUTO_TEST_CASE(compileRawArrayLabel)
@@ -58,28 +58,28 @@ BOOST_AUTO_TEST_CASE(compileRawArrayLabel)
     StateTestFillerTransaction tr = makeTransaction({":raw 0x1234", ":label sample :raw 0x2244"});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel().empty());
     BOOST_CHECK(tr.buildTransactions().at(1).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x1234");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString() == "0x2244");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x1234");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString() == "0x2244");
 }
 
 BOOST_AUTO_TEST_CASE(compileLLL)
 {
     StateTestFillerTransaction tr = makeTransaction({"{ [[1]] 1 }"});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x600160015500");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x600160015500");
 }
 
 BOOST_AUTO_TEST_CASE(compileLLLLabel)
 {
     StateTestFillerTransaction tr = makeTransaction({":label sample { [[1]] 1 }"});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x600160015500");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x600160015500");
 }
 
 BOOST_AUTO_TEST_CASE(compileLLLArray)
 {
     StateTestFillerTransaction tr = makeTransaction({"{ [[1]] 1 }", "{ [[1]] 2 }"});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x600160015500");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString() == "0x600260015500");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x600160015500");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString() == "0x600260015500");
 }
 
 BOOST_AUTO_TEST_CASE(compileLLLArrayLabel)
@@ -87,14 +87,14 @@ BOOST_AUTO_TEST_CASE(compileLLLArrayLabel)
     StateTestFillerTransaction tr = makeTransaction({"{ [[1]] 1 }", ":label sample { [[1]] 2 }"});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel().empty());
     BOOST_CHECK(tr.buildTransactions().at(1).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() == "0x600160015500");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString() == "0x600260015500");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() == "0x600160015500");
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString() == "0x600260015500");
 }
 
 BOOST_AUTO_TEST_CASE(compileABI)
 {
     StateTestFillerTransaction tr = makeTransaction({":abi f(uint) 12"});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() ==
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() ==
                 "0x693c6139000000000000000000000000000000000000000000000000000000000000000c");
 }
 
@@ -102,16 +102,16 @@ BOOST_AUTO_TEST_CASE(compileABILabel)
 {
     StateTestFillerTransaction tr = makeTransaction({":label sample :abi f(uint) 12"});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() ==
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() ==
                 "0x693c6139000000000000000000000000000000000000000000000000000000000000000c");
 }
 
 BOOST_AUTO_TEST_CASE(compileABIArray)
 {
     StateTestFillerTransaction tr = makeTransaction({":abi f(uint) 12", ":abi f(uint) 13"});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() ==
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() ==
                 "0x693c6139000000000000000000000000000000000000000000000000000000000000000c");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString() ==
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString() ==
                 "0x693c6139000000000000000000000000000000000000000000000000000000000000000d");
 }
 
@@ -120,9 +120,9 @@ BOOST_AUTO_TEST_CASE(compileABIArrayLabel)
     StateTestFillerTransaction tr = makeTransaction({":abi f(uint) 13", ":label sample :abi f(uint) 12"});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel().empty());
     BOOST_CHECK(tr.buildTransactions().at(1).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString() ==
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString() ==
                 "0x693c6139000000000000000000000000000000000000000000000000000000000000000d");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString() ==
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString() ==
                 "0x693c6139000000000000000000000000000000000000000000000000000000000000000c");
 }
 
@@ -153,21 +153,21 @@ string const solContractC =
 BOOST_AUTO_TEST_CASE(compileSOLC)
 {
     StateTestFillerTransaction tr = makeTransaction({solContract});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
 }
 
 BOOST_AUTO_TEST_CASE(compileSOLCLabel)
 {
     StateTestFillerTransaction tr = makeTransaction({":label sample " + solContract});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
 }
 
 BOOST_AUTO_TEST_CASE(compileSOLCArray)
 {
     StateTestFillerTransaction tr = makeTransaction({solContract, solContract});
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString().substr(0, 50) == solContractC.substr(0, 50));
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString().substr(0, 50) == solContractC.substr(0, 50));
 }
 
 BOOST_AUTO_TEST_CASE(compileSOLCArrayLabel)
@@ -175,8 +175,8 @@ BOOST_AUTO_TEST_CASE(compileSOLCArrayLabel)
     StateTestFillerTransaction tr = makeTransaction({solContract, ":label sample " + solContract});
     BOOST_CHECK(tr.buildTransactions().at(0).transaction()->dataLabel().empty());
     BOOST_CHECK(tr.buildTransactions().at(1).transaction()->dataLabel() == ":label sample");
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
-    BOOST_CHECK(tr.asDataObject().atKey("data").at(1).asString().substr(0, 50) == solContractC.substr(0, 50));
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(0).asString().substr(0, 50) == solContractC.substr(0, 50));
+    BOOST_CHECK(tr.asDataObject()->atKey("data").at(1).asString().substr(0, 50) == solContractC.substr(0, 50));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
this is an attempt to optimize memory copy operations in DataObject
This branch show 30-38% execution speed increase on VPS
Yet more refactoring and optimizations to be done. 

* better memory usage, less copies, map response for keys in DataObject
* DataObject subobjects are stored as smart pointer 
* use shared memory device for tmp files if possible

bcForgedTest is disabled due to :bigint  upgrade that will allow to generate invalid tests with oversized fields (in json and rlp)
the test protocol with besu and t8ntool would need to be adjusted to facilitate those tests