### PR TITLE
fix(docs): typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # retesteth
-testeth via RPC (wiki: https://github.com/ethereum/retesteth/wiki)  
+testeth via RPC (wiki: https://github.com/ethereum/retesteth/wiki)
 (Execution stats: http://retesteth.ethdevops.io/)
 
-* A test generaion tool for the test fillers https://github.com/ethereum/tests/tree/develop/src  
+* A test generation tool for the test fillers https://github.com/ethereum/tests/tree/develop/src
 * Building instruction for beginners: [retesteth + solidity build](https://github.com/ethereum/retesteth#building-instructions-for-beginners)
 * [Usage tutorial](https://ethereum-tests.readthedocs.io/en/latest/retesteth-tutorial.html)
 
 # The Goal
 
-* A test tool that would be capable of running current Blockchain tests against any client by sending rpc request to the client instatnce on either local or remote host. (using unix or TCP sockets) 
-* Filling existing tests (generating post state from *Filler.json instruction files) using rpc and any exisiting client
-* Running rpc request - response tests with a provided client on localhost
+* A test tool that would be capable of running current Blockchain tests against any client by sending RPC request to the client instance on either local or remote host. (using unix or TCP sockets)
+* Filling existing tests (generating post state from *Filler.json instruction files) using RPC and any existing client
+* Running RPC request - response tests with a provided client on localhost
 * Bunch tests execution with many clients with many threads
-* A minimum set of additional rpc methods for client to negotiate with the tool: https://github.com/ethereum/retesteth/wiki/RPC-Methods
+* A minimum set of additional RPC methods for client to negotiate with the tool: https://github.com/ethereum/retesteth/wiki/RPC-Methods
 
 # Current progress
 
-* done: State tests execution and filling was done as PoC on ethereum cpp client (aleth)
-* done: Tests execution using threads on localhost with multimple instances of a client (geth + aleth)
-* done: Develop minimum set of rpc methods that are to be implemented on other clients and could be used to run tests via rpc
+* done: State tests execution and filling was done as PoC on Ethereum cpp client (aleth)
+* done: Tests execution using threads on localhost with multiple instances of a client (geth + aleth)
+* done: Develop minimum set of RPC methods that are to be implemented on other clients and could be used to run tests via RPC
 * done: PoC Running Blockchain tests using geth client
 * done: Implement a set of PoC methods in other client then aleth
 * done: Refactoring and stability when generating GeneralStateTests
 * done: Blockchain test generation support
 * now: Use retesteth to produce fork tests with geth/besu/aleth
-* now: Refactor the code, impove stability
+* now: Refactor the code, improve stability
 
 # Building instructions
 ```
@@ -35,14 +35,14 @@ cd build
 cmake ..
 make -j4
 ```
-Or try building instruction for begginers: [retesteth + solidity build](https://github.com/ethereum/retesteth#building-instructions-for-beginners)
+Or try building instruction for beginners: [retesteth + solidity build](https://github.com/ethereum/retesteth#building-instructions-for-beginners)
 
 
 # Usage
-WIKI: https://github.com/ethereum/retesteth/wiki  
-Requres to have a client installed on your system. Read the wiki page on detailed instruction on how to configure your client to work with `retesteth`
+Wiki: https://github.com/ethereum/retesteth/wiki
+Requires to have a client installed on your system. Read the wiki page on detailed instruction on how to configure your client to work with `retesteth`
 https://github.com/ethereum/retesteth/wiki/Add-client-configuration-to-Retesteth
-```
+```bash
 ./retesteth -t GeneralStateTests
 ```
 
@@ -82,11 +82,11 @@ cd build
 cmake ..
 ```
 
-Now you should see the successful build files generation result: 
+Now you should see the successful build files generation result:
 ```
 Configuring done
 -- Generating done
--- Build files have been written 
+-- Build files have been written
 ```
 
 Run the build command to compile:
@@ -97,10 +97,10 @@ make -j4
 
 #### Solidity
 
-check the available boost version by  
+check the available boost version by
 `sudo apt-cache policy libboost-all-dev`
 
-install boost dependency boost if version >=1.65  
+install boost dependency boost if version >=1.65
 `sudo apt-get install libboost-all-dev`
 
 Solidity building instructions:
@@ -118,5 +118,3 @@ make lllc -j4
 ```
 
 ### DONE!
-
-


### PR DESCRIPTION
1. Fix typos
2. `rpc` -> `RPC`