### PR TITLE
Revert "Show data label in redundant expect section when filling chain tests"

### DIFF
--- a/retesteth/testSuites/StateTests.cpp
+++ b/retesteth/testSuites/StateTests.cpp
@@ -202,7 +202,7 @@ spDataObject FillTestAsBlockchain(StateTestInFiller const& _test)
                     dataPostfix += "_" + fork.asString();
 
                     if (filledTest->count(_test.testName() + dataPostfix))
-                        ETH_ERROR_MESSAGE("The test filler contain redundant expect section: " + _test.testName() + dataPostfix + " (" + tr.transaction()->dataLabel() + ")");
+                        ETH_ERROR_MESSAGE("The test filler contain redundunt expect section: " + _test.testName() + dataPostfix);
 
                     verifyFilledTest(_test.unitTestVerifyBC(), aBlockchainTest, fork);
                     (*filledTest).atKeyPointer(_test.testName() + dataPostfix) = aBlockchainTest;


### PR DESCRIPTION
Reverts ethereum/retesteth#181